### PR TITLE
Factor out common test case code, no functionality changed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig: http://editorconfig.org/
+
+root = true
+
+[*.{java,md,rq,ttl,xml,yml}]
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.7.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.nanohttpd</groupId>
             <artifactId>nanohttpd</artifactId>
             <version>2.3.1</version>
@@ -79,12 +85,13 @@
                 <version>0.12</version>
                 <configuration>
                     <excludes>
-                        <exclude>README.md</exclude>
-                        <exclude>pom.xml</exclude>
-                        <exclude>circle.yml</exclude>
-                        <exclude>settings.xml</exclude>
+                        <exclude>.editorconfig</exclude>
                         <exclude>LICENSE.txt</exclude>
                         <exclude>NOTICE.txt</exclude>
+                        <exclude>README.md</exclude>
+                        <exclude>circle.yml</exclude>
+                        <exclude>pom.xml</exclude>
+                        <exclude>settings.xml</exclude>
                         <exclude>**/META-INF/services/*</exclude>
                         <exclude>**/test/resources/*</exclude>
                     </excludes>
@@ -123,6 +130,21 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>banned-deps</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>commons-logging</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>pedantic-pom</id>
                         <goals>

--- a/src/test/java/world/data/jdbc/DataWorldJdbcDriverTest.java
+++ b/src/test/java/world/data/jdbc/DataWorldJdbcDriverTest.java
@@ -20,15 +20,15 @@ package world.data.jdbc;
 
 import org.junit.Test;
 
-import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLFeatureNotSupported;
 
 public class DataWorldJdbcDriverTest {
     @Test
     public void acceptsURL() throws Exception {
-        final DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
+        DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
         assertThat(driver.acceptsURL("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset")).isTrue();
         assertThat(driver.acceptsURL("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset")).isTrue();
         assertThat(driver.acceptsURL("mysql:dave:lahman-sabremetrics-dataset")).isFalse();
@@ -36,47 +36,45 @@ public class DataWorldJdbcDriverTest {
 
     @Test
     public void connect() throws Exception {
-        final DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
+        DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
         assertThat(driver.connect("mysql:dave:lahman-sabremetrics-dataset", null)).isNull();
     }
 
     @Test
     public void connectWithOverride() throws Exception {
-        final DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
-        final Properties props = new Properties();
+        DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
+        Properties props = new Properties();
         props.setProperty("queryBaseUrl", "http://localhost:9092");
         assertThat(driver.connect("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", props)).isNotNull();
     }
 
     @Test
     public void getMajorVersion() throws Exception {
-        final DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
+        DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
         assertThat(driver.getMajorVersion()).isEqualTo(1);
-
     }
 
     @Test
     public void getMinorVersion() throws Exception {
-        final DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
+        DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
         assertThat(driver.getMinorVersion()).isEqualTo(0);
     }
 
     @Test
     public void getPropertyInfo() throws Exception {
-        final DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
+        DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
         assertThat(driver.getPropertyInfo(null, null).length).isEqualTo(0);
     }
 
     @Test
     public void jdbcCompliant() throws Exception {
-        final DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
+        DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
         assertThat(driver.jdbcCompliant()).isEqualTo(false);
     }
 
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getParentLogger() throws Exception {
-        final DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
-        driver.getParentLogger();
+    @Test
+    public void testAllNotSupported() throws Exception {
+        DataWorldJdbcDriver driver = new DataWorldJdbcDriver();
+        assertSQLFeatureNotSupported(driver::getParentLogger);
     }
-
 }

--- a/src/test/java/world/data/jdbc/DataWorldSparqlMetadataTest.java
+++ b/src/test/java/world/data/jdbc/DataWorldSparqlMetadataTest.java
@@ -18,23 +18,29 @@
 */
 package world.data.jdbc;
 
+import org.junit.Rule;
 import org.junit.Test;
+import world.data.jdbc.testing.SparqlHelper;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.RowIdLifetime;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLException;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLFeatureNotSupported;
 
 public class DataWorldSparqlMetadataTest {
+
+    @Rule
+    public final SparqlHelper sparql = new SparqlHelper();
+
     @Test
     public void test() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        final DatabaseMetaData metaData = connection.getMetaData();
+        Connection connection = sparql.connect();
+        DatabaseMetaData metaData = connection.getMetaData();
         assertThat(metaData.allProceduresAreCallable()).isFalse();
         assertThat(metaData.allTablesAreSelectable()).isTrue();
         assertThat(metaData.autoCommitFailureClosesAllResultSets()).isFalse();
@@ -196,35 +202,25 @@ public class DataWorldSparqlMetadataTest {
         assertThat(metaData.getResultSetHoldability()).isEqualTo(ResultSet.CLOSE_CURSORS_AT_COMMIT);
         assertThat(getResultSetSize(metaData.getTypeInfo())).isEqualTo(21);
         assertThat(getResultSetSize(metaData.getSchemas())).isEqualTo(1);
-
     }
 
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testIsWrapperFor() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        final DatabaseMetaData metaData = connection.getMetaData();
-        metaData.isWrapperFor(Class.class);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testUnwrap() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        final DatabaseMetaData metaData = connection.getMetaData();
-        metaData.unwrap(Class.class);
-    }
-
-    @Test(expected = SQLException.class)
+    @Test
     public void testNullConnection() throws SQLException {
-        final DatabaseMetaData metaData = new DataWorldSqlMetadata(null);
-        metaData.unwrap(Class.class);
+        assertSQLException(() -> new DataWorldSqlMetadata(null));
     }
 
-    private int getResultSetSize(final ResultSet resultSet) throws SQLException {
+    @Test
+    public void testAllNotSupported() throws SQLException {
+        DatabaseMetaData metaData = sparql.connect().getMetaData();
+        assertSQLFeatureNotSupported(() -> metaData.isWrapperFor(Class.class));
+        assertSQLFeatureNotSupported(() -> metaData.unwrap(Class.class));
+    }
+
+    private int getResultSetSize(ResultSet resultSet) throws SQLException {
         int count = 0;
         while (resultSet.next()) {
             count++;
         }
         return count;
     }
-
 }

--- a/src/test/java/world/data/jdbc/SparqlTest.java
+++ b/src/test/java/world/data/jdbc/SparqlTest.java
@@ -20,22 +20,29 @@ package world.data.jdbc;
 
 import fi.iki.elonen.NanoHTTPD;
 import org.apache.commons.io.IOUtils;
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import world.data.jdbc.testing.NanoHTTPDHandler;
+import world.data.jdbc.testing.NanoHTTPDResource;
+import world.data.jdbc.testing.SparqlHelper;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
 import java.sql.Statement;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static fi.iki.elonen.NanoHTTPD.Method.GET;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLException;
 
 public class SparqlTest {
 
-    private static String lastUri;
+    private static NanoHTTPDHandler lastBackendRequest;
     private static String resultResourceName;
     private static String resultMimeType;
 
@@ -43,207 +50,208 @@ public class SparqlTest {
     public static final NanoHTTPDResource proxiedServer = new NanoHTTPDResource(3333) {
         @Override
         protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) throws Exception {
-            final String queryParameterString = session.getQueryParameterString();
-            if (queryParameterString != null) {
-                lastUri = "http://localhost:3333" + session.getUri() + '?' + queryParameterString;
-            } else {
-                lastUri = "http://localhost:3333" + session.getUri();
+            String authorization = session.getHeaders().get("authorization");
+            if (!"Bearer access-token".equals(authorization)) {
+                return newResponse(NanoHTTPD.Response.Status.UNAUTHORIZED, "text/plain", "Missing or incorrect password");
             }
-            return newResponse(NanoHTTPD.Response.Status.OK, resultMimeType, IOUtils.toString(SparqlTest.class.getResourceAsStream("/" + resultResourceName)));
+            NanoHTTPDHandler.invoke(session, lastBackendRequest);
+            String body = IOUtils.toString(getClass().getResourceAsStream(resultResourceName), UTF_8);
+            return newResponse(NanoHTTPD.Response.Status.OK, resultMimeType, body);
         }
     };
 
+    @Rule
+    public final SparqlHelper sparql = new SparqlHelper();
+
+    @Before
+    public void setup() {
+        lastBackendRequest = mock(NanoHTTPDHandler.class);
+    }
+
     @Test
     public void test() throws Exception {
-        resultResourceName = "select.json";
+        resultResourceName = "/select.json";
         resultMimeType = "application/json";
 
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where{?s ?p ?o.} limit 10")) {
-            ResultSetMetaData rsmd = resultSet.getMetaData();
-            int columnsNumber = rsmd.getColumnCount();
+        Statement statement = sparql.createStatement(sparql.connect());
+        ResultSet resultSet = sparql.executeQuery(statement, "select ?s ?p ?o where{?s ?p ?o.} limit 10");
+        ResultSetMetaData rsmd = resultSet.getMetaData();
+        int columnsNumber = rsmd.getColumnCount();
+        for (int i = 1; i <= columnsNumber; i++) {
+            if (i > 1) {
+                System.out.print(",  ");
+            }
+            System.out.print(rsmd.getColumnName(i));
+        }
+        System.out.println("");
+        while (resultSet.next()) {
             for (int i = 1; i <= columnsNumber; i++) {
                 if (i > 1) {
                     System.out.print(",  ");
                 }
-                System.out.print(rsmd.getColumnName(i));
+                String columnValue = resultSet.getString(i);
+                System.out.print(columnValue);
             }
             System.out.println("");
-            while (resultSet.next()) {
-                for (int i = 1; i <= columnsNumber; i++) {
-                    if (i > 1) {
-                        System.out.print(",  ");
-                    }
-                    String columnValue = resultSet.getString(i);
-                    System.out.print(columnValue);
-                }
-                System.out.println("");
-            }
         }
-        assertThat(lastUri).isEqualTo("http://localhost:3333/sparql/dave/lahman-sabremetrics-dataset?query=SELECT++%3Fs+%3Fp+%3Fo%0AWHERE%0A++%7B+%3Fs++%3Fp++%3Fo+%7D%0ALIMIT+++10%0A");
+        verify(lastBackendRequest).handle(GET, "/sparql/dave/lahman-sabremetrics-dataset",
+                "query=SELECT++%3Fs+%3Fp+%3Fo%0AWHERE%0A++%7B+%3Fs++%3Fp++%3Fo+%7D%0ALIMIT+++10%0A");
     }
 
     @Test
     public void testAsk() throws Exception {
         resultMimeType = "application/json";
-        resultResourceName = "ask.json";
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("ask{?s ?p ?o.}")) {
-            ResultSetMetaData rsmd = resultSet.getMetaData();
-            int columnsNumber = rsmd.getColumnCount();
+        resultResourceName = "/ask.json";
+
+        Statement statement = sparql.createStatement(sparql.connect());
+        ResultSet resultSet = sparql.executeQuery(statement, "ask{?s ?p ?o.}");
+        ResultSetMetaData rsmd = resultSet.getMetaData();
+        int columnsNumber = rsmd.getColumnCount();
+        for (int i = 1; i <= columnsNumber; i++) {
+            if (i > 1) {
+                System.out.print(",  ");
+            }
+            System.out.print(rsmd.getColumnName(i));
+        }
+        System.out.println("");
+        while (resultSet.next()) {
             for (int i = 1; i <= columnsNumber; i++) {
                 if (i > 1) {
                     System.out.print(",  ");
                 }
-                System.out.print(rsmd.getColumnName(i));
+                String columnValue = resultSet.getString(i);
+                System.out.print(columnValue);
             }
             System.out.println("");
-            while (resultSet.next()) {
-                for (int i = 1; i <= columnsNumber; i++) {
-                    if (i > 1) {
-                        System.out.print(",  ");
-                    }
-                    String columnValue = resultSet.getString(i);
-                    System.out.print(columnValue);
-                }
-                System.out.println("");
-            }
         }
-        assertThat(lastUri).isEqualTo("http://localhost:3333/sparql/dave/lahman-sabremetrics-dataset?query=ASK%0AWHERE%0A++%7B+%3Fs++%3Fp++%3Fo+%7D%0A");
+        verify(lastBackendRequest).handle(GET, "/sparql/dave/lahman-sabremetrics-dataset",
+                "query=ASK%0AWHERE%0A++%7B+%3Fs++%3Fp++%3Fo+%7D%0A");
     }
 
     @Test
     public void testDescribe() throws Exception {
-        resultResourceName = "describe.xml";
+        resultResourceName = "/describe.xml";
         resultMimeType = "application/rdf+xml";
 
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("DESCRIBE ?s where{?s ?p ?o.} limit 10")) {
-            ResultSetMetaData rsmd = resultSet.getMetaData();
-            int columnsNumber = rsmd.getColumnCount();
+        Statement statement = sparql.createStatement(sparql.connect());
+        ResultSet resultSet = sparql.executeQuery(statement, "DESCRIBE ?s where{?s ?p ?o.} limit 10");
+        ResultSetMetaData rsmd = resultSet.getMetaData();
+        int columnsNumber = rsmd.getColumnCount();
+        for (int i = 1; i <= columnsNumber; i++) {
+            if (i > 1) {
+                System.out.print(",  ");
+            }
+            System.out.print(rsmd.getColumnName(i));
+        }
+        System.out.println("");
+        while (resultSet.next()) {
             for (int i = 1; i <= columnsNumber; i++) {
                 if (i > 1) {
                     System.out.print(",  ");
                 }
-                System.out.print(rsmd.getColumnName(i));
+                String columnValue = resultSet.getString(i);
+                System.out.print(columnValue);
             }
             System.out.println("");
-            while (resultSet.next()) {
-                for (int i = 1; i <= columnsNumber; i++) {
-                    if (i > 1) {
-                        System.out.print(",  ");
-                    }
-                    String columnValue = resultSet.getString(i);
-                    System.out.print(columnValue);
-                }
-                System.out.println("");
-            }
         }
-        assertThat(lastUri).isEqualTo("http://localhost:3333/sparql/dave/lahman-sabremetrics-dataset?query=DESCRIBE+%3Fs%0AWHERE%0A++%7B+%3Fs++%3Fp++%3Fo+%7D%0ALIMIT+++10%0A");
+        verify(lastBackendRequest).handle(GET, "/sparql/dave/lahman-sabremetrics-dataset",
+                "query=DESCRIBE+%3Fs%0AWHERE%0A++%7B+%3Fs++%3Fp++%3Fo+%7D%0ALIMIT+++10%0A");
     }
 
     @Test
     public void testConstruct() throws Exception {
-        resultResourceName = "construct.xml";
+        resultResourceName = "/construct.xml";
         resultMimeType = "application/rdf+xml";
 
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("Construct{?o ?p ?s} where{?s ?p ?o.} limit 10")) {
-            ResultSetMetaData rsmd = resultSet.getMetaData();
-            int columnsNumber = rsmd.getColumnCount();
+        Statement statement = sparql.createStatement(sparql.connect());
+        ResultSet resultSet = sparql.executeQuery(statement, "Construct{?o ?p ?s} where{?s ?p ?o.} limit 10");
+        ResultSetMetaData rsmd = resultSet.getMetaData();
+        int columnsNumber = rsmd.getColumnCount();
+        for (int i = 1; i <= columnsNumber; i++) {
+            if (i > 1) {
+                System.out.print(",  ");
+            }
+            System.out.print(rsmd.getColumnName(i));
+        }
+        System.out.println("");
+        while (resultSet.next()) {
             for (int i = 1; i <= columnsNumber; i++) {
                 if (i > 1) {
                     System.out.print(",  ");
                 }
-                System.out.print(rsmd.getColumnName(i));
+                String columnValue = resultSet.getString(i);
+                System.out.print(columnValue);
             }
             System.out.println("");
-            while (resultSet.next()) {
-                for (int i = 1; i <= columnsNumber; i++) {
-                    if (i > 1) {
-                        System.out.print(",  ");
-                    }
-                    String columnValue = resultSet.getString(i);
-                    System.out.print(columnValue);
-                }
-                System.out.println("");
-            }
         }
-        assertThat(lastUri).isEqualTo("http://localhost:3333/sparql/dave/lahman-sabremetrics-dataset?query=CONSTRUCT+%0A++%7B+%0A++++%3Fo+%3Fp+%3Fs+.%0A++%7D%0AWHERE%0A++%7B+%3Fs++%3Fp++%3Fo+%7D%0ALIMIT+++10%0A");
+        verify(lastBackendRequest).handle(GET, "/sparql/dave/lahman-sabremetrics-dataset",
+                "query=CONSTRUCT+%0A++%7B+%0A++++%3Fo+%3Fp+%3Fs+.%0A++%7D%0AWHERE%0A++%7B+%3Fs++%3Fp++%3Fo+%7D%0ALIMIT+++10%0A");
     }
 
     @Test
     public void testConstructTurtle() throws Exception {
-        resultResourceName = "construct.ttl";
+        resultResourceName = "/construct.ttl";
         resultMimeType = "text/turtle";
 
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("Construct{?o ?p ?s} where{?s ?p ?o.} limit 10")) {
-            ResultSetMetaData rsmd = resultSet.getMetaData();
-            int columnsNumber = rsmd.getColumnCount();
+        Statement statement = sparql.createStatement(sparql.connect());
+        ResultSet resultSet = sparql.executeQuery(statement, "Construct{?o ?p ?s} where{?s ?p ?o.} limit 10");
+        ResultSetMetaData rsmd = resultSet.getMetaData();
+        int columnsNumber = rsmd.getColumnCount();
+        for (int i = 1; i <= columnsNumber; i++) {
+            if (i > 1) {
+                System.out.print(",  ");
+            }
+            System.out.print(rsmd.getColumnName(i));
+        }
+        System.out.println("");
+        while (resultSet.next()) {
             for (int i = 1; i <= columnsNumber; i++) {
                 if (i > 1) {
                     System.out.print(",  ");
                 }
-                System.out.print(rsmd.getColumnName(i));
+                String columnValue = resultSet.getString(i);
+                System.out.print(columnValue);
             }
             System.out.println("");
-            while (resultSet.next()) {
-                for (int i = 1; i <= columnsNumber; i++) {
-                    if (i > 1) {
-                        System.out.print(",  ");
-                    }
-                    String columnValue = resultSet.getString(i);
-                    System.out.print(columnValue);
-                }
-                System.out.println("");
-            }
         }
-        assertThat(lastUri).isEqualTo("http://localhost:3333/sparql/dave/lahman-sabremetrics-dataset?query=CONSTRUCT+%0A++%7B+%0A++++%3Fo+%3Fp+%3Fs+.%0A++%7D%0AWHERE%0A++%7B+%3Fs++%3Fp++%3Fo+%7D%0ALIMIT+++10%0A");
+        verify(lastBackendRequest).handle(GET, "/sparql/dave/lahman-sabremetrics-dataset",
+                "query=CONSTRUCT+%0A++%7B+%0A++++%3Fo+%3Fp+%3Fs+.%0A++%7D%0AWHERE%0A++%7B+%3Fs++%3Fp++%3Fo+%7D%0ALIMIT+++10%0A");
     }
 
     @Test
     public void testPrepared() throws Exception {
-        resultResourceName = "select.json";
+        resultResourceName = "/select.json";
         resultMimeType = "application/json";
 
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select ?s ?p ?o where{?s ?p ?o.} limit 10");
-             final ResultSet resultSet = statement.executeQuery()) {
-            ResultSetMetaData rsmd = resultSet.getMetaData();
-            int columnsNumber = rsmd.getColumnCount();
+        Connection connection = sparql.connect();
+        PreparedStatement statement = sparql.prepareStatement(connection, "select ?s ?p ?o where{?s ?p ?o.} limit 10");
+        ResultSet resultSet = sparql.executeQuery(statement);
+        ResultSetMetaData rsmd = resultSet.getMetaData();
+        int columnsNumber = rsmd.getColumnCount();
+        for (int i = 1; i <= columnsNumber; i++) {
+            if (i > 1) {
+                System.out.print(",  ");
+            }
+            System.out.print(rsmd.getColumnName(i));
+        }
+        System.out.println("");
+        while (resultSet.next()) {
             for (int i = 1; i <= columnsNumber; i++) {
                 if (i > 1) {
                     System.out.print(",  ");
                 }
-                System.out.print(rsmd.getColumnName(i));
+                String columnValue = resultSet.getString(i);
+                System.out.print(columnValue);
             }
             System.out.println("");
-            while (resultSet.next()) {
-                for (int i = 1; i <= columnsNumber; i++) {
-                    if (i > 1) {
-                        System.out.print(",  ");
-                    }
-                    String columnValue = resultSet.getString(i);
-                    System.out.print(columnValue);
-                }
-                System.out.println("");
-            }
         }
-        assertThat(lastUri).isEqualTo("http://localhost:3333/sparql/dave/lahman-sabremetrics-dataset?query=SELECT++%3Fs+%3Fp+%3Fo%0AWHERE%0A++%7B+%3Fs++%3Fp++%3Fo+%7D%0ALIMIT+++10%0A");
+        verify(lastBackendRequest).handle(GET, "/sparql/dave/lahman-sabremetrics-dataset",
+                "query=SELECT++%3Fs+%3Fp+%3Fo%0AWHERE%0A++%7B+%3Fs++%3Fp++%3Fo+%7D%0ALIMIT+++10%0A");
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void testBadQuery() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where{?s ?p ?o.} limit ?")) {
-
-        }
+        Statement statement = sparql.createStatement(sparql.connect());
+        assertSQLException(() -> statement.executeQuery("select ?s ?p ?o where{?s ?p ?o.} limit ?"));
     }
 }

--- a/src/test/java/world/data/jdbc/SqlTest.java
+++ b/src/test/java/world/data/jdbc/SqlTest.java
@@ -20,441 +20,207 @@ package world.data.jdbc;
 
 import fi.iki.elonen.NanoHTTPD;
 import org.apache.commons.io.IOUtils;
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import world.data.jdbc.connections.DataWorldConnection;
+import world.data.jdbc.statements.DataWorldPreparedStatement;
+import world.data.jdbc.testing.NanoHTTPDHandler;
+import world.data.jdbc.testing.NanoHTTPDResource;
+import world.data.jdbc.testing.SqlHelper;
 
 import java.io.InputStream;
 import java.io.Reader;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.NClob;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 
+import static fi.iki.elonen.NanoHTTPD.Method.GET;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLException;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLFeatureNotSupported;
 
 public class SqlTest {
 
-    private static String lastUri;
-    private static final String resultResourceName = "hall_of_fame.json";
+    private static NanoHTTPDHandler lastBackendRequest;
+    private static final String resultResourceName = "/hall_of_fame.json";
     private static final String resultMimeType = "application/json";
 
     @ClassRule
     public static final NanoHTTPDResource proxiedServer = new NanoHTTPDResource(3333) {
         @Override
         protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) throws Exception {
-            final String queryParameterString = session.getQueryParameterString();
-            if (queryParameterString != null) {
-                lastUri = "http://localhost:3333" + session.getUri() + '?' + queryParameterString;
-            } else {
-                lastUri = "http://localhost:3333" + session.getUri();
+            String authorization = session.getHeaders().get("authorization");
+            if (!"Bearer access-token".equals(authorization)) {
+                return newResponse(NanoHTTPD.Response.Status.UNAUTHORIZED, "text/plain", "Missing or incorrect password");
             }
-            return newResponse(NanoHTTPD.Response.Status.OK, resultMimeType, IOUtils.toString(SparqlTest.class.getResourceAsStream("/" + resultResourceName)));
+            NanoHTTPDHandler.invoke(session, lastBackendRequest);
+            String body = IOUtils.toString(getClass().getResourceAsStream(resultResourceName), UTF_8);
+            return newResponse(NanoHTTPD.Response.Status.OK, resultMimeType, body);
         }
     };
 
+    @Rule
+    public final SqlHelper sql = new SqlHelper();
+
+    @Before
+    public void setup() {
+        lastBackendRequest = mock(NanoHTTPDHandler.class);
+    }
+
+    private DataWorldPreparedStatement samplePreparedStatement() throws SQLException {
+        Connection connection = sql.connect();
+        return sql.prepareStatement(connection, "select * from HallOfFame where yearid > ? order by yearid, playerID limit 10");
+    }
+
+    private ResultSet sampleResultSet() throws SQLException {
+        Statement statement = sql.createStatement(sql.connect());
+        return sql.executeQuery(statement, "select * from HallOfFame order by yearid, playerID limit 10");
+    }
+
     @Test
     public void test() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement()) {
-            try (final ResultSet resultSet = statement.executeQuery("select * from HallOfFame order by yearid, playerID limit 10")) {
-                ResultSetMetaData rsmd = resultSet.getMetaData();
-                int columnsNumber = rsmd.getColumnCount();
-                for (int i = 1; i <= columnsNumber; i++) {
-                    if (i > 1) {
-                        System.out.print(",  ");
-                    }
-                    System.out.print(rsmd.getColumnName(i));
-                }
-                System.out.println("");
-                while (resultSet.next()) {
-                    for (int i = 1; i <= columnsNumber; i++) {
-                        if (i > 1) {
-                            System.out.print(",  ");
-                        }
-                        String columnValue = resultSet.getString(i);
-                        System.out.print(columnValue);
-                    }
-                    System.out.println("");
-                }
+        Statement statement = sql.createStatement(sql.connect());
+        ResultSet resultSet = sql.executeQuery(statement, "select * from HallOfFame order by yearid, playerID limit 10 ");
+        ResultSetMetaData rsmd = resultSet.getMetaData();
+        int columnsNumber = rsmd.getColumnCount();
+        for (int i = 1; i <= columnsNumber; i++) {
+            if (i > 1) {
+                System.out.print(",  ");
             }
+            System.out.print(rsmd.getColumnName(i));
         }
-        assertThat(lastUri).isEqualTo("http://localhost:3333/sql/dave/lahman-sabremetrics-dataset?query=select+*+from+HallOfFame+order+by+yearid%2C+playerID+limit+10");
+        System.out.println("");
+        while (resultSet.next()) {
+            for (int i = 1; i <= columnsNumber; i++) {
+                if (i > 1) {
+                    System.out.print(",  ");
+                }
+                String columnValue = resultSet.getString(i);
+                System.out.print(columnValue);
+            }
+            System.out.println("");
+        }
+        verify(lastBackendRequest).handle(GET, "/sql/dave/lahman-sabremetrics-dataset",
+                "query=select+*+from+HallOfFame+order+by+yearid%2C+playerID+limit+10+");
     }
 
     @Test
     public void testPrepared() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setInt(1, 3);
-            try (final ResultSet resultSet = statement.executeQuery()) {
-                ResultSetMetaData rsmd = resultSet.getMetaData();
-                int columnsNumber = rsmd.getColumnCount();
-                for (int i = 1; i <= columnsNumber; i++) {
-                    if (i > 1) {
-                        System.out.print(",  ");
-                    }
-                    System.out.print(rsmd.getColumnName(i));
-                }
-                System.out.println("");
-                while (resultSet.next()) {
-                    for (int i = 1; i <= columnsNumber; i++) {
-                        if (i > 1) {
-                            System.out.print(",  ");
-                        }
-                        String columnValue = resultSet.getString(i);
-                        System.out.print(columnValue);
-                    }
-                    System.out.println("");
-                }
+        DataWorldConnection connection = sql.connect();
+        PreparedStatement statement = sql.prepareStatement(connection, "select * from HallOfFame where yearid > ? order by yearid, playerID limit 10 ");
+        statement.setInt(1, 3);
+        ResultSet resultSet = sql.executeQuery(statement);
+        ResultSetMetaData rsmd = resultSet.getMetaData();
+        int columnsNumber = rsmd.getColumnCount();
+        for (int i = 1; i <= columnsNumber; i++) {
+            if (i > 1) {
+                System.out.print(",  ");
             }
+            System.out.print(rsmd.getColumnName(i));
         }
-        assertThat(lastUri).isEqualTo("http://localhost:3333/sql/dave/lahman-sabremetrics-dataset?query=select+*+from+HallOfFame+where+yearid+%3E+%3F+order+by+yearid%2C+playerID+limit+10&parameters=%24data_world_param0%3D%223%22%5E%5E%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23integer%3E");
-
+        System.out.println("");
+        while (resultSet.next()) {
+            for (int i = 1; i <= columnsNumber; i++) {
+                if (i > 1) {
+                    System.out.print(",  ");
+                }
+                String columnValue = resultSet.getString(i);
+                System.out.print(columnValue);
+            }
+            System.out.println("");
+        }
+        verify(lastBackendRequest).handle(GET, "/sql/dave/lahman-sabremetrics-dataset",
+                "query=select+*+from+HallOfFame+where+yearid+%3E+%3F+order+by+yearid%2C+playerID+limit+10+" +
+                        "&parameters=%24data_world_param0%3D%223%22%5E%5E%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23integer%3E");
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void testIndexOutOfBounds() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setInt(1, 3);
-            statement.setString(2, "foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetArray() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setArray(1, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetAsciiStream() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setAsciiStream(1, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetAsciiStream2() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setAsciiStream(1, null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetAsciiStream3() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setAsciiStream(1, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetBinaryStream() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setBinaryStream(1, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetBinaryStream2() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setBinaryStream(1, null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetBinaryStream3() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setBinaryStream(1, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetCharacterStream() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setCharacterStream(1, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testBytes() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setBytes(1, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetCharacterStream2() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setCharacterStream(1, null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetCharacterStream3() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setCharacterStream(1, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetBlob() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setBlob(1, (Blob) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetBlob2() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setBlob(1, (InputStream) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetBlob3() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setBlob(1, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetClob() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setClob(1, (Clob) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetClob2() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setClob(1, (Reader) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetClob3() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setClob(1, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetNCharacterStream() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setNCharacterStream(1, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetNCharacterStream2() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setNCharacterStream(1, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetNClob() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setNClob(1, (NClob) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetNClob2() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setNClob(1, (Reader) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetNClob3() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setNClob(1, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetRef() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setRef(1, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetRowId() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setRowId(1, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSQLXML() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setSQLXML(1, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetDate() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setDate(1, null, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetTime() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setTime(1, null, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetTimestamp() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setTimestamp(1, null, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetUnicodeStream() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final PreparedStatement statement = connection.prepareStatement("select * from HallOfFame where yearid > ? order by yearid, playerID limit 10")) {
-            statement.setUnicodeStream(1, null, 3);
-        }
+        PreparedStatement statement = samplePreparedStatement();
+        statement.setInt(1, 3);
+        assertSQLException(() -> statement.setString(2, "foo"));
     }
 
     @Test
     public void testMetadataQueries() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement()) {
-            try (final ResultSet resultSet = statement.executeQuery("select * from HallOfFame order by yearid, playerID limit 10")) {
-                final ResultSetMetaData metaData = resultSet.getMetaData();
-                assertThat(metaData.getColumnCount()).isEqualTo(10);
-                assertThat(metaData.getColumnClassName(1)).isEqualTo("java.lang.String");
-                assertThat(metaData.getColumnDisplaySize(1)).isEqualTo(Integer.MAX_VALUE);
-                assertThat(metaData.getColumnLabel(1)).isEqualTo("playerID");
-                assertThat(metaData.getColumnName(1)).isEqualTo("playerID");
-                assertThat(metaData.getScale(1)).isEqualTo(0);
-                assertThat(metaData.getPrecision(1)).isEqualTo(0);
-                assertThat(metaData.getSchemaName(1)).isEqualTo("");
-                assertThat(metaData.getTableName(1)).isEqualTo("");
-                assertThat(metaData.isNullable(1)).isEqualTo(1);
-                assertThat(metaData.isSigned(1)).isEqualTo(false);
-                assertThat(metaData.isAutoIncrement(1)).isEqualTo(false);
-                assertThat(metaData.isCaseSensitive(1)).isEqualTo(true);
-                assertThat(metaData.isCurrency(1)).isEqualTo(false);
-                assertThat(metaData.isDefinitelyWritable(1)).isEqualTo(false);
-                assertThat(metaData.isReadOnly(1)).isEqualTo(true);
-                assertThat(metaData.isSearchable(1)).isEqualTo(true);
-                assertThat(metaData.isWritable(1)).isEqualTo(false);
-                assertThat(metaData.getColumnType(1)).isEqualTo(-9);
-                assertThat(metaData.getColumnTypeName(1)).isEqualTo("org.apache.jena.graph.Node");
-                assertThat(metaData.getCatalogName(1)).isEqualTo("RDF");
-            }
-        }
+        Statement statement = sql.createStatement(sql.connect());
+        ResultSet resultSet = sql.executeQuery(statement, "select * from HallOfFame order by yearid, playerID limit 10");
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        assertThat(metaData.getColumnCount()).isEqualTo(10);
+        assertThat(metaData.getColumnClassName(1)).isEqualTo("java.lang.String");
+        assertThat(metaData.getColumnDisplaySize(1)).isEqualTo(Integer.MAX_VALUE);
+        assertThat(metaData.getColumnLabel(1)).isEqualTo("playerID");
+        assertThat(metaData.getColumnName(1)).isEqualTo("playerID");
+        assertThat(metaData.getScale(1)).isEqualTo(0);
+        assertThat(metaData.getPrecision(1)).isEqualTo(0);
+        assertThat(metaData.getSchemaName(1)).isEqualTo("");
+        assertThat(metaData.getTableName(1)).isEqualTo("");
+        assertThat(metaData.isNullable(1)).isEqualTo(1);
+        assertThat(metaData.isSigned(1)).isEqualTo(false);
+        assertThat(metaData.isAutoIncrement(1)).isEqualTo(false);
+        assertThat(metaData.isCaseSensitive(1)).isEqualTo(true);
+        assertThat(metaData.isCurrency(1)).isEqualTo(false);
+        assertThat(metaData.isDefinitelyWritable(1)).isEqualTo(false);
+        assertThat(metaData.isReadOnly(1)).isEqualTo(true);
+        assertThat(metaData.isSearchable(1)).isEqualTo(true);
+        assertThat(metaData.isWritable(1)).isEqualTo(false);
+        assertThat(metaData.getColumnType(1)).isEqualTo(-9);
+        assertThat(metaData.getColumnTypeName(1)).isEqualTo("org.apache.jena.graph.Node");
+        assertThat(metaData.getCatalogName(1)).isEqualTo("RDF");
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void testMetadataQueryOutOfRange() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement()) {
-            try (final ResultSet resultSet = statement.executeQuery("select * from HallOfFame order by yearid, playerID limit 10")) {
-                final ResultSetMetaData metaData = resultSet.getMetaData();
-                assertThat(metaData.getColumnClassName(11)).isEqualTo("java.lang.String");
-            }
-        }
+        ResultSetMetaData metaData = sampleResultSet().getMetaData();
+        assertSQLException(() -> metaData.getColumnClassName(11));
     }
 
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testMetadataIsWrapperFor() throws Exception {
+    @Test
+    public void testAllNotSupported() throws Exception {
+        PreparedStatement statement = samplePreparedStatement();
+        assertSQLFeatureNotSupported(() -> statement.setArray(1, null));
+        assertSQLFeatureNotSupported(() -> statement.setAsciiStream(1, null));
+        assertSQLFeatureNotSupported(() -> statement.setAsciiStream(1, null, 3));
+        assertSQLFeatureNotSupported(() -> statement.setAsciiStream(1, null, 3L));
+        assertSQLFeatureNotSupported(() -> statement.setBinaryStream(1, null));
+        assertSQLFeatureNotSupported(() -> statement.setBinaryStream(1, null, 3));
+        assertSQLFeatureNotSupported(() -> statement.setBinaryStream(1, null, 3L));
+        assertSQLFeatureNotSupported(() -> statement.setBlob(1, (Blob) null));
+        assertSQLFeatureNotSupported(() -> statement.setBlob(1, (InputStream) null));
+        assertSQLFeatureNotSupported(() -> statement.setBlob(1, null, 3L));
+        assertSQLFeatureNotSupported(() -> statement.setBytes(1, null));
+        assertSQLFeatureNotSupported(() -> statement.setCharacterStream(1, null));
+        assertSQLFeatureNotSupported(() -> statement.setCharacterStream(1, null, 3));
+        assertSQLFeatureNotSupported(() -> statement.setCharacterStream(1, null, 3L));
+        assertSQLFeatureNotSupported(() -> statement.setClob(1, (Clob) null));
+        assertSQLFeatureNotSupported(() -> statement.setClob(1, (Reader) null));
+        assertSQLFeatureNotSupported(() -> statement.setClob(1, null, 3L));
+        assertSQLFeatureNotSupported(() -> statement.setDate(1, null, null));
+        assertSQLFeatureNotSupported(() -> statement.setNCharacterStream(1, null));
+        assertSQLFeatureNotSupported(() -> statement.setNCharacterStream(1, null, 3L));
+        assertSQLFeatureNotSupported(() -> statement.setNClob(1, (NClob) null));
+        assertSQLFeatureNotSupported(() -> statement.setNClob(1, (Reader) null));
+        assertSQLFeatureNotSupported(() -> statement.setNClob(1, null, 3L));
+        assertSQLFeatureNotSupported(() -> statement.setRef(1, null));
+        assertSQLFeatureNotSupported(() -> statement.setRowId(1, null));
+        assertSQLFeatureNotSupported(() -> statement.setSQLXML(1, null));
+        assertSQLFeatureNotSupported(() -> statement.setTime(1, null, null));
+        assertSQLFeatureNotSupported(() -> statement.setTimestamp(1, null, null));
+        assertSQLFeatureNotSupported(() -> statement.setUnicodeStream(1, null, 3));
 
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement()) {
-            try (final ResultSet resultSet = statement.executeQuery("select * from HallOfFame order by yearid, playerID limit 10")) {
-                resultSet.getMetaData().isWrapperFor(Class.class);
-            }
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testMetadataUnwrap() throws Exception {
-
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement()) {
-            try (final ResultSet resultSet = statement.executeQuery("select * from HallOfFame order by yearid, playerID limit 10")) {
-                resultSet.getMetaData().unwrap(Class.class);
-            }
-        }
+        ResultSetMetaData md = sampleResultSet().getMetaData();
+        assertSQLFeatureNotSupported(() -> md.isWrapperFor(Class.class));
+        assertSQLFeatureNotSupported(() -> md.unwrap(Class.class));
     }
 }

--- a/src/test/java/world/data/jdbc/connections/DataWorldConnectionTest.java
+++ b/src/test/java/world/data/jdbc/connections/DataWorldConnectionTest.java
@@ -18,369 +18,112 @@
 */
 package world.data.jdbc.connections;
 
+import org.junit.Rule;
 import org.junit.Test;
-import world.data.jdbc.TestConfigSource;
+import world.data.jdbc.testing.SparqlHelper;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLException;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLFeatureNotSupported;
 
 public class DataWorldConnectionTest {
 
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testCreateArray() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.createArrayOf("String", new Object[0]);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testCreateBlob() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.createBlob();
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testCreateClob() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.createClob();
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testCreateNClob() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.createNClob();
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testCreateSQLXML() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.createSQLXML();
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testCreateStruct() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.createStruct("String", new Object[0]);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testGetTypeMap() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.getTypeMap();
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testNativeSql() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.nativeSQL("");
-    }
-
-    @Test(expected = SQLException.class)
-    public void testPrepareCallClosede() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.prepareCall("");
-    }
-
-    @Test(expected = SQLException.class)
-    public void testPrepareCall2Closed() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.prepareCall("", 0, 0);
-    }
-
-    @Test(expected = SQLException.class)
-    public void testPrepareCall3Closed() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.prepareCall("", 0, 0, 0);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testReleaseSavepoint() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.releaseSavepoint(null);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testRollbackSavepoint() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.rollback(null);
-    }
-
-    @Test(expected = SQLException.class)
-    public void testRollbackClosed() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.rollback();
-    }
+    @Rule
+    public final SparqlHelper sparql = new SparqlHelper();
 
     @Test
     public void testRollbackNotClosed() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+        Connection connection = sparql.connect();
         connection.rollback();
-    }
-
-    @Test(expected = SQLException.class)
-    public void testCommitClosed() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.commit();
     }
 
     @Test
     public void testCommitNotClosed() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+        Connection connection = sparql.connect();
         connection.commit();
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetSavepoint() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.setSavepoint();
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetNamedSavepoint() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.setSavepoint("");
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetCatalog() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.setCatalog(null);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetTransactionIsolation() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
     }
 
     @Test
     public void testSetTransactionIsolationOkay() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+        Connection connection = sparql.connect();
         connection.setTransactionIsolation(Connection.TRANSACTION_NONE);
     }
 
     @Test
     public void testSetAutocommitOkay() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+        Connection connection = sparql.connect();
         connection.setAutoCommit(true);
         connection.setAutoCommit(false);
         connection.setAutoCommit(true);
     }
 
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetSchema() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.setSchema("foo");
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testIsWrapperFor() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.isWrapperFor(this.getClass());
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testUnwrap() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.unwrap(this.getClass());
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetTypeMap() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.setTypeMap(null);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testSetNetworkTimeout() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.setNetworkTimeout(null, 1000);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testGetNetworkTimeout() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.getNetworkTimeout();
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testGetSchema() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.getSchema();
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testAbort() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.abort(null);
-    }
-
     @Test
     public void testHoldability() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+        Connection connection = sparql.connect();
         connection.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT);
     }
 
-    @Test(expected = SQLException.class)
-    public void testBadHoldability() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.setHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT);
+    @Test
+    public void testBadHoldability() throws Exception {
+        Connection connection = sparql.connect();
+        assertSQLException(() -> connection.setHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT));
     }
 
-    @Test(expected = SQLException.class)
-    public void testSetReadOnly() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.setReadOnly(false);
+    @Test
+    public void testSetReadOnly() throws Exception {
+        Connection connection = sparql.connect();
+        assertSQLException(() -> connection.setReadOnly(false));
     }
 
     @Test
     public void testSetReadOnlyOkay() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+        Connection connection = sparql.connect();
         connection.setReadOnly(true);
-    }
-
-    @Test(expected = SQLException.class)
-    public void testSetReadOnlyClosed() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.setReadOnly(false);
     }
 
     @Test()
     public void testClientInfo() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+        Connection connection = sparql.connect();
         connection.setClientInfo("foo", "bar");
         assertThat(connection.getClientInfo("foo")).isEqualTo("bar");
     }
 
     @Test()
     public void testClientInfoBatch() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        final Properties props = new Properties();
+        Connection connection = sparql.connect();
+        Properties props = new Properties();
         props.setProperty("foo", "bar");
         connection.setClientInfo(props);
         assertThat(connection.getClientInfo("foo")).isEqualTo("bar");
         assertThat(connection.getClientInfo().getProperty("foo")).isEqualTo("bar");
     }
 
-    @Test(expected = SQLException.class)
-    public void testCreateStatementClosed() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.createStatement();
-    }
-
-    @Test(expected = SQLException.class)
-    public void testCreateStatementClosed2() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.createStatement(0, 0);
-    }
-
-    @Test(expected = SQLException.class)
-    public void testCreateStatementClosed3() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.createStatement(0, 0, 0);
-    }
-
-    @Test(expected = SQLException.class)
-    public void testprepareStatementClosed() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.prepareStatement("");
-    }
-
-    @Test(expected = SQLException.class)
-    public void testprepareStatementClosed2() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.prepareStatement("", 0, 0);
-    }
-
-    @Test(expected = SQLException.class)
-    public void testprepareStatementClosed3() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.prepareStatement("", 0, 0, 0);
-    }
-
-    @Test(expected = SQLException.class)
-    public void testprepareStatementAutoClosed() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.prepareStatement("", 3);
-    }
-
-    @Test(expected = SQLException.class)
-    public void testprepareStatementIndexClosed() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.prepareStatement("", (int[]) null);
-    }
-
-    @Test(expected = SQLException.class)
-    public void testprepareStatementColumnNamesClosed() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.close();
-        connection.prepareStatement("", (String[]) null);
-    }
-
     @Test
-    public void testprepareStatementAuto() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+    public void testPrepareStatementAuto() throws SQLException {
+        Connection connection = sparql.connect();
         connection.prepareStatement("", 3);
     }
 
     @Test
-    public void testprepareStatementIndex() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+    public void testPrepareStatementIndex() throws SQLException {
+        Connection connection = sparql.connect();
         connection.prepareStatement("", (int[]) null);
     }
 
     @Test
-    public void testprepareStatementColumnNames() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+    public void testPrepareStatementColumnNames() throws SQLException {
+        Connection connection = sparql.connect();
         connection.prepareStatement("", (String[]) null);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testprepareStatementScrolling() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.prepareStatement("", ResultSet.TYPE_SCROLL_INSENSITIVE, 0, 0);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testprepareStatementConcurrency() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.prepareStatement("", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE, 0);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testCreateStatementScrolling() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, 0, 0);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testCreateStatementConcurrency() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-        connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE, 0);
     }
 
     @Test
     public void testIsValid() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+        Connection connection = sparql.connect();
         assertThat(connection.isValid(0)).isTrue();
         connection.close();
         assertThat(connection.isValid(0)).isFalse();
@@ -388,19 +131,71 @@ public class DataWorldConnectionTest {
 
     @Test
     public void testIsReadOnly() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+        Connection connection = sparql.connect();
         assertThat(connection.isReadOnly()).isTrue();
     }
 
     @Test
     public void testGetAutocommit() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+        Connection connection = sparql.connect();
         assertThat(connection.getAutoCommit()).isTrue();
     }
 
     @Test
     public void testGetTransactionIsolation() throws SQLException {
-        final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
+        Connection connection = sparql.connect();
         assertThat(connection.getTransactionIsolation()).isEqualTo(Connection.TRANSACTION_NONE);
+    }
+
+    @Test
+    public void testAllClosed() throws Exception {
+        Connection connection = sparql.connect();
+        connection.close();
+        assertSQLException(connection::commit);
+        assertSQLException(connection::createStatement);
+        assertSQLException(() -> connection.createStatement(0, 0));
+        assertSQLException(() -> connection.createStatement(0, 0, 0));
+        assertSQLException(() -> connection.prepareCall(""));
+        assertSQLException(() -> connection.prepareCall("", 0, 0));
+        assertSQLException(() -> connection.prepareCall("", 0, 0, 0));
+        assertSQLException(() -> connection.prepareStatement(""));
+        assertSQLException(() -> connection.prepareStatement("", (String[]) null));
+        assertSQLException(() -> connection.prepareStatement("", (int[]) null));
+        assertSQLException(() -> connection.prepareStatement("", 0, 0));
+        assertSQLException(() -> connection.prepareStatement("", 0, 0, 0));
+        assertSQLException(() -> connection.prepareStatement("", 3));
+        assertSQLException(connection::rollback);
+        assertSQLException(() -> connection.setReadOnly(false));
+    }
+
+    @Test
+    public void testAllNotSupported() throws Exception {
+        Connection connection = sparql.connect();
+        assertSQLFeatureNotSupported(() -> connection.abort(null));
+        assertSQLFeatureNotSupported(() -> connection.createArrayOf("String", new Object[0]));
+        assertSQLFeatureNotSupported(connection::createBlob);
+        assertSQLFeatureNotSupported(connection::createClob);
+        assertSQLFeatureNotSupported(connection::createNClob);
+        assertSQLFeatureNotSupported(connection::createSQLXML);
+        assertSQLFeatureNotSupported(() -> connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE, 0));
+        assertSQLFeatureNotSupported(() -> connection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, 0, 0));
+        assertSQLFeatureNotSupported(() -> connection.createStruct("String", new Object[0]));
+        assertSQLFeatureNotSupported(connection::getNetworkTimeout);
+        assertSQLFeatureNotSupported(connection::getSchema);
+        assertSQLFeatureNotSupported(connection::getTypeMap);
+        assertSQLFeatureNotSupported(() -> connection.isWrapperFor(this.getClass()));
+        assertSQLFeatureNotSupported(() -> connection.nativeSQL(""));
+        assertSQLFeatureNotSupported(() -> connection.prepareStatement("", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE, 0));
+        assertSQLFeatureNotSupported(() -> connection.prepareStatement("", ResultSet.TYPE_SCROLL_INSENSITIVE, 0, 0));
+        assertSQLFeatureNotSupported(() -> connection.releaseSavepoint(null));
+        assertSQLFeatureNotSupported(() -> connection.rollback(null));
+        assertSQLFeatureNotSupported(() -> connection.setCatalog(null));
+        assertSQLFeatureNotSupported(() -> connection.setNetworkTimeout(null, 1000));
+        assertSQLFeatureNotSupported(() -> connection.setSavepoint(""));
+        assertSQLFeatureNotSupported(connection::setSavepoint);
+        assertSQLFeatureNotSupported(() -> connection.setSchema("foo"));
+        assertSQLFeatureNotSupported(() -> connection.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED));
+        assertSQLFeatureNotSupported(() -> connection.setTypeMap(null));
+        assertSQLFeatureNotSupported(() -> connection.unwrap(this.getClass()));
     }
 }

--- a/src/test/java/world/data/jdbc/results/DataWorldResultsSetTest.java
+++ b/src/test/java/world/data/jdbc/results/DataWorldResultsSetTest.java
@@ -20,98 +20,67 @@ package world.data.jdbc.results;
 
 import fi.iki.elonen.NanoHTTPD;
 import org.apache.commons.io.IOUtils;
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
-import world.data.jdbc.NanoHTTPDResource;
-import world.data.jdbc.SparqlTest;
-import world.data.jdbc.TestConfigSource;
+import world.data.jdbc.testing.NanoHTTPDHandler;
+import world.data.jdbc.testing.NanoHTTPDResource;
+import world.data.jdbc.testing.SparqlHelper;
 
 import java.io.InputStream;
 import java.io.Reader;
 import java.sql.Blob;
 import java.sql.Clob;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.NClob;
 import java.sql.ResultSet;
-import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collections;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLFeatureNotSupported;
 
 public class DataWorldResultsSetTest {
-    private static String lastUri;
-    private static String resultResourceName = "select.json";
-    private static String resultMimeType = "application/json";
+    private static NanoHTTPDHandler lastBackendRequest;
+    private static final String resultResourceName = "/select.json";
+    private static final String resultMimeType = "application/json";
 
     @ClassRule
     public static final NanoHTTPDResource proxiedServer = new NanoHTTPDResource(3333) {
         @Override
         protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) throws Exception {
-            final String queryParameterString = session.getQueryParameterString();
-            if (queryParameterString != null) {
-                lastUri = "http://localhost:3333" + session.getUri() + '?' + queryParameterString;
-            } else {
-                lastUri = "http://localhost:3333" + session.getUri();
-            }
-            return newResponse(NanoHTTPD.Response.Status.OK, resultMimeType, IOUtils.toString(SparqlTest.class.getResourceAsStream("/" + resultResourceName)));
+            NanoHTTPDHandler.invoke(session, lastBackendRequest);
+            String body = IOUtils.toString(getClass().getResourceAsStream(resultResourceName), UTF_8);
+            return newResponse(NanoHTTPD.Response.Status.OK, resultMimeType, body);
         }
     };
 
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void isWrapperFor() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.isWrapperFor(Class.class);
-        }
+    @Rule
+    public final SparqlHelper sparql = new SparqlHelper();
+
+    @Before
+    public void setup() {
+        lastBackendRequest = mock(NanoHTTPDHandler.class);
     }
 
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void unwrap() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.unwrap(Class.class);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void cancelRowUpdates() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.cancelRowUpdates();
-        }
-    }
-
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void deleteRow() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.deleteRow();
-        }
+    private ResultSet sampleResultSet() throws SQLException {
+        Statement statement = sparql.createStatement(sparql.connect());
+        return sparql.executeQuery(statement, "select ?s ?p ?o where {?s ?p ?o.}");
     }
 
     @Test
     public void getHoldability() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            assertThat(resultSet.getHoldability()).isEqualTo(ResultSet.CLOSE_CURSORS_AT_COMMIT);
-        }
+        ResultSet resultSet = sampleResultSet();
+        assertThat(resultSet.getHoldability()).isEqualTo(ResultSet.CLOSE_CURSORS_AT_COMMIT);
     }
 
     @Test
     public void getConcurrency() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            assertThat(resultSet.getConcurrency()).isEqualTo(ResultSet.CONCUR_READ_ONLY);
-        }
+        ResultSet resultSet = sampleResultSet();
+        assertThat(resultSet.getConcurrency()).isEqualTo(ResultSet.CONCUR_READ_ONLY);
     }
 
     @Test
@@ -269,360 +238,9 @@ public class DataWorldResultsSetTest {
 
     }
 
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getArray() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getArray(1);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getArray1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getArray("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getAsciiStream() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getAsciiStream(1);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getAsciiStream1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getAsciiStream("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getBigDecimal2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getBigDecimal("foo", 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getBigDecimal3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getBigDecimal(3, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getBinaryStream() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getBinaryStream(3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getBinaryStream1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getBinaryStream("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getBlob() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getBlob("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getBlob1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getBlob(3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getBytes() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getBytes("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getBytes1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getBytes(3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getCharacterStream() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getCharacterStream("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getCharacterStream1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getCharacterStream(3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getClob() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getClob("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getClob1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getClob(3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getCursorName() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getCursorName();
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getDate2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getDate("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getDate3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getDate(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getNCharacterStream() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getNCharacterStream("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getNCharacterStream1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getNCharacterStream(3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getNClob() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getNClob("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getNClob1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getNClob(3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getObject2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getObject("foo", String.class);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getObject3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getObject(3, String.class);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getObject4() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getObject("foo", Collections.emptyMap());
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getObject5() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getObject(3, Collections.emptyMap());
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getRef() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getRef("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getRef1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getRef(3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getRowId() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getRowId("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getRowId1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getRowId(3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getSQLXML() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getSQLXML("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getSQLXML1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getSQLXML(3);
-        }
-    }
-
     @Test
     public void getStatement() throws Exception {
 
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getTime2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getTime("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getTime3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getTime(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getTimestamp2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getTimestamp("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getTimestamp3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getTimestamp(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getUnicodeStream() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getUnicodeStream("foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void getUnicodeStream1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.getUnicodeStream(3);
-        }
     }
 
     @Test
@@ -630,846 +248,170 @@ public class DataWorldResultsSetTest {
 
     }
 
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void insertRow() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.insertRow();
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void moveToCurrentRow() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.moveToCurrentRow();
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void moveToInsertRow() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.moveToInsertRow();
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void previous() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.previous();
-        }
-    }
-
     @Test
     public void refreshRow() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.refreshRow();
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.refreshRow();
     }
 
     @Test
     public void rowDeleted() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            assertThat(resultSet.rowDeleted()).isFalse();
-        }
+        ResultSet resultSet = sampleResultSet();
+        assertThat(resultSet.rowDeleted()).isFalse();
     }
 
     @Test
     public void rowInserted() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            assertThat(resultSet.rowInserted()).isFalse();
-        }
+        ResultSet resultSet = sampleResultSet();
+        assertThat(resultSet.rowInserted()).isFalse();
     }
 
     @Test
     public void rowUpdated() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            assertThat(resultSet.rowUpdated()).isFalse();
-        }
+        ResultSet resultSet = sampleResultSet();
+        assertThat(resultSet.rowUpdated()).isFalse();
     }
 
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateArray() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateArray(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateArray1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateArray("s", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateAsciiStream() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateAsciiStream(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateAsciiStream1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateAsciiStream(3, null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateAsciiStream2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateAsciiStream(3, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateAsciiStream3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateAsciiStream("foo", null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateAsciiStream4() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateAsciiStream("foo", null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateAsciiStream5() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateAsciiStream("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBigDecimal() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBigDecimal("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBigDecimal1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBigDecimal(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBinaryStream() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBinaryStream(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBinaryStream1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBinaryStream(3, null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBinaryStream2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBinaryStream(3, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBinaryStream3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBinaryStream("foo", null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBinaryStream4() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBinaryStream("foo", null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBinaryStream5() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBinaryStream("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBlob() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBlob(3, (InputStream) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBlob1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBlob(3, (Blob) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBlob2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBlob(3, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBlob3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBlob("foo", null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBlob4() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBlob("foo", (Blob) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBlob5() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBlob("foo", (InputStream) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBoolean() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBoolean("foo", true);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBoolean1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBoolean(3, true);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateByte() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateByte(3, (byte) 2);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateByte1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateByte("foo", (byte) 2);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBytes() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBytes("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateBytes1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateBytes(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateCharacterStream() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateCharacterStream(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateCharacterStream1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateCharacterStream(3, null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateCharacterStream2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateCharacterStream(3, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateCharacterStream3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateCharacterStream("foo", null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateCharacterStream4() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateCharacterStream("foo", null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateCharacterStream5() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateCharacterStream("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateClob() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateClob(3, (Reader) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateClob1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateClob(3, (Clob) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateClob2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateClob(3, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateClob3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateClob("foo", null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateClob4() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateClob("foo", (Clob) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateClob5() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateClob("foo", (Reader) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateDate() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateDate("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateDate1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateDate(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateDouble() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateDouble("foo", 3.0);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateDouble1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateDouble(3, 3.0);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateFloat() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateFloat("foo", 3.0f);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateFloat1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateFloat(3, 3.0f);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateInt() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateInt("foo", 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateInt1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateInt(3, 4);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateLong() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateLong("foo", 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateLong1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateLong(3, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNCharacterStream() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNCharacterStream(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNCharacterStream1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNCharacterStream(3, null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNCharacterStream2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNCharacterStream(3, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNCharacterStream3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNCharacterStream("foo", null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNCharacterStream4() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNCharacterStream("foo", null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNCharacterStream5() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNCharacterStream("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNClob() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNClob(3, (Reader) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNClob1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNClob(3, (NClob) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNClob2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNClob(3, null, 3L);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNClob3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNClob("foo", null, 3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNClob4() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNClob("foo", (NClob) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNClob5() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNClob("foo", (Reader) null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNString() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNString(3, "foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNString1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNString("bar", "foo");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNull() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNull("bar");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateNull1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateNull(3);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateObject() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateObject("bar", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateObject1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateObject("bar", null, 2);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateObject2() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateObject(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateObject3() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateObject(3, null, 2);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateRef() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateRef(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateRef1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateRef("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateRow() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateRow();
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateRowId() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateRowId(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateRowId1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateRowId("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateSQLXML() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateSQLXML(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateSQLXML1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateSQLXML("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateShort() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateShort(3, (short) 2);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateShort1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateShort("foo", (short) 2);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateString() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateString("foo", "bar");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateString1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateString(3, "bar");
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateTime() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateTime(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateTime1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateTime("foo", null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateTimestamp() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateTimestamp(3, null);
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void updateTimestamp1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s ?p ?o where {?s ?p ?o.}")) {
-            resultSet.updateTimestamp("foo", null);
-        }
-    }
-
+    @Test
     public void wasNull() throws Exception {
 
     }
 
-
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testAllNotSupported() throws Exception {
+        ResultSet resultSet = sampleResultSet();
+        assertSQLFeatureNotSupported(resultSet::cancelRowUpdates);
+        assertSQLFeatureNotSupported(resultSet::deleteRow);
+        assertSQLFeatureNotSupported(() -> resultSet.getArray("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getArray(1));
+        assertSQLFeatureNotSupported(() -> resultSet.getAsciiStream("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getAsciiStream(1));
+        assertSQLFeatureNotSupported(() -> resultSet.getBigDecimal("foo", 3));
+        assertSQLFeatureNotSupported(() -> resultSet.getBigDecimal(3, 3));
+        assertSQLFeatureNotSupported(() -> resultSet.getBinaryStream("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getBinaryStream(3));
+        assertSQLFeatureNotSupported(() -> resultSet.getBlob("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getBlob(3));
+        assertSQLFeatureNotSupported(() -> resultSet.getBytes("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getBytes(3));
+        assertSQLFeatureNotSupported(() -> resultSet.getCharacterStream("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getCharacterStream(3));
+        assertSQLFeatureNotSupported(() -> resultSet.getClob("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getClob(3));
+        assertSQLFeatureNotSupported(resultSet::getCursorName);
+        assertSQLFeatureNotSupported(() -> resultSet.getDate("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.getDate(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.getNCharacterStream("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getNCharacterStream(3));
+        assertSQLFeatureNotSupported(() -> resultSet.getNClob("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getNClob(3));
+        assertSQLFeatureNotSupported(() -> resultSet.getObject("foo", Collections.emptyMap()));
+        assertSQLFeatureNotSupported(() -> resultSet.getObject("foo", String.class));
+        assertSQLFeatureNotSupported(() -> resultSet.getObject(3, Collections.emptyMap()));
+        assertSQLFeatureNotSupported(() -> resultSet.getObject(3, String.class));
+        assertSQLFeatureNotSupported(() -> resultSet.getRef("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getRef(3));
+        assertSQLFeatureNotSupported(() -> resultSet.getRowId("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getRowId(3));
+        assertSQLFeatureNotSupported(() -> resultSet.getSQLXML("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getSQLXML(3));
+        assertSQLFeatureNotSupported(() -> resultSet.getTime("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.getTime(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.getTimestamp("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.getTimestamp(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.getUnicodeStream("foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.getUnicodeStream(3));
+        assertSQLFeatureNotSupported(resultSet::insertRow);
+        assertSQLFeatureNotSupported(() -> resultSet.isWrapperFor(Class.class));
+        assertSQLFeatureNotSupported(resultSet::moveToCurrentRow);
+        assertSQLFeatureNotSupported(resultSet::moveToInsertRow);
+        assertSQLFeatureNotSupported(resultSet::previous);
+        assertSQLFeatureNotSupported(() -> resultSet.unwrap(Class.class));
+        assertSQLFeatureNotSupported(() -> resultSet.updateArray("s", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateArray(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateAsciiStream("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateAsciiStream("foo", null, 3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateAsciiStream("foo", null, 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateAsciiStream(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateAsciiStream(3, null, 3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateAsciiStream(3, null, 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBigDecimal("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBigDecimal(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBinaryStream("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBinaryStream("foo", null, 3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBinaryStream("foo", null, 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBinaryStream(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBinaryStream(3, null, 3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBinaryStream(3, null, 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBlob("foo", (Blob) null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBlob("foo", (InputStream) null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBlob("foo", null, 3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBlob(3, (Blob) null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBlob(3, (InputStream) null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBlob(3, null, 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBoolean("foo", true));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBoolean(3, true));
+        assertSQLFeatureNotSupported(() -> resultSet.updateByte("foo", (byte) 2));
+        assertSQLFeatureNotSupported(() -> resultSet.updateByte(3, (byte) 2));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBytes("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateBytes(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateCharacterStream("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateCharacterStream("foo", null, 3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateCharacterStream("foo", null, 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateCharacterStream(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateCharacterStream(3, null, 3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateCharacterStream(3, null, 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateClob("foo", (Clob) null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateClob("foo", (Reader) null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateClob("foo", null, 3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateClob(3, (Clob) null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateClob(3, (Reader) null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateClob(3, null, 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateDate("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateDate(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateDouble("foo", 3.0));
+        assertSQLFeatureNotSupported(() -> resultSet.updateDouble(3, 3.0));
+        assertSQLFeatureNotSupported(() -> resultSet.updateFloat("foo", 3.0f));
+        assertSQLFeatureNotSupported(() -> resultSet.updateFloat(3, 3.0f));
+        assertSQLFeatureNotSupported(() -> resultSet.updateInt("foo", 3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateInt(3, 4));
+        assertSQLFeatureNotSupported(() -> resultSet.updateLong("foo", 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateLong(3, 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNCharacterStream("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNCharacterStream("foo", null, 3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNCharacterStream("foo", null, 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNCharacterStream(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNCharacterStream(3, null, 3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNCharacterStream(3, null, 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNClob("foo", (NClob) null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNClob("foo", (Reader) null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNClob("foo", null, 3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNClob(3, (NClob) null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNClob(3, (Reader) null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNClob(3, null, 3L));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNString("bar", "foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNString(3, "foo"));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNull("bar"));
+        assertSQLFeatureNotSupported(() -> resultSet.updateNull(3));
+        assertSQLFeatureNotSupported(() -> resultSet.updateObject("bar", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateObject("bar", null, 2));
+        assertSQLFeatureNotSupported(() -> resultSet.updateObject(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateObject(3, null, 2));
+        assertSQLFeatureNotSupported(() -> resultSet.updateRef("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateRef(3, null));
+        assertSQLFeatureNotSupported(resultSet::updateRow);
+        assertSQLFeatureNotSupported(() -> resultSet.updateRowId("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateRowId(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateSQLXML("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateSQLXML(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateShort("foo", (short) 2));
+        assertSQLFeatureNotSupported(() -> resultSet.updateShort(3, (short) 2));
+        assertSQLFeatureNotSupported(() -> resultSet.updateString("foo", "bar"));
+        assertSQLFeatureNotSupported(() -> resultSet.updateString(3, "bar"));
+        assertSQLFeatureNotSupported(() -> resultSet.updateTime("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateTime(3, null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateTimestamp("foo", null));
+        assertSQLFeatureNotSupported(() -> resultSet.updateTimestamp(3, null));
+    }
 }

--- a/src/test/java/world/data/jdbc/results/GetValuesTest.java
+++ b/src/test/java/world/data/jdbc/results/GetValuesTest.java
@@ -20,81 +20,84 @@ package world.data.jdbc.results;
 
 import fi.iki.elonen.NanoHTTPD;
 import org.apache.commons.io.IOUtils;
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import world.data.jdbc.JdbcCompatibility;
-import world.data.jdbc.NanoHTTPDResource;
-import world.data.jdbc.SparqlTest;
-import world.data.jdbc.TestConfigSource;
 import world.data.jdbc.statements.DataWorldStatement;
+import world.data.jdbc.testing.NanoHTTPDHandler;
+import world.data.jdbc.testing.NanoHTTPDResource;
+import world.data.jdbc.testing.SqlHelper;
 
 import java.math.BigDecimal;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class GetValuesTest {
-    private static String lastUri;
-    private static final String resultResourceName = "hall_of_fame.json";
+    private static NanoHTTPDHandler lastBackendRequest;
+    private static final String resultResourceName = "/hall_of_fame.json";
     private static final String resultMimeType = "application/json";
 
     @ClassRule
     public static final NanoHTTPDResource proxiedServer = new NanoHTTPDResource(3333) {
         @Override
         protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) throws Exception {
-            final String queryParameterString = session.getQueryParameterString();
-            if (queryParameterString != null) {
-                lastUri = "http://localhost:3333" + session.getUri() + '?' + queryParameterString;
-            } else {
-                lastUri = "http://localhost:3333" + session.getUri();
-            }
-            return newResponse(NanoHTTPD.Response.Status.OK, resultMimeType, IOUtils.toString(SparqlTest.class.getResourceAsStream("/" + resultResourceName)));
+            NanoHTTPDHandler.invoke(session, lastBackendRequest);
+            String body = IOUtils.toString(getClass().getResourceAsStream(resultResourceName), UTF_8);
+            return newResponse(NanoHTTPD.Response.Status.OK, resultMimeType, body);
         }
     };
 
+    @Rule
+    public final SqlHelper sql = new SqlHelper();
+
+    @Before
+    public void setup() {
+        lastBackendRequest = mock(NanoHTTPDHandler.class);
+    }
+
+    private ResultSet sampleResultSet() throws SQLException {
+        Statement statement = sql.createStatement(sql.connect());
+        return sql.executeQuery(statement, "select * from HallOfFame limit 10");
+    }
+
     @Test
     public void getBigDecimal() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select * from HallOfFame limit 10")) {
-            resultSet.next();
-            assertThat(resultSet.getBigDecimal(2)).isEqualTo(new BigDecimal(1936));
-            assertThat(resultSet.getBigDecimal("yearid")).isEqualTo(new BigDecimal(1936));
-            assertThat(resultSet.wasNull()).isFalse();
-            assertThat(resultSet.getBigDecimal("null_col")).isNull();
-            assertThat(resultSet.wasNull()).isTrue();
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getBigDecimal(2)).isEqualTo(new BigDecimal(1936));
+        assertThat(resultSet.getBigDecimal("yearid")).isEqualTo(new BigDecimal(1936));
+        assertThat(resultSet.wasNull()).isFalse();
+        assertThat(resultSet.getBigDecimal("null_col")).isNull();
+        assertThat(resultSet.wasNull()).isTrue();
     }
 
     @Test
     public void getBoolean1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select * from HallOfFame limit 10")) {
-            resultSet.next();
-            assertThat(resultSet.getBoolean(7)).isEqualTo(true);
-            assertThat(resultSet.getBoolean("inducted")).isEqualTo(true);
-            assertThat(resultSet.wasNull()).isFalse();
-            assertThat(resultSet.getBoolean("null_col")).isEqualTo(false);
-            assertThat(resultSet.wasNull()).isTrue();
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getBoolean(7)).isEqualTo(true);
+        assertThat(resultSet.getBoolean("inducted")).isEqualTo(true);
+        assertThat(resultSet.wasNull()).isFalse();
+        assertThat(resultSet.getBoolean("null_col")).isEqualTo(false);
+        assertThat(resultSet.wasNull()).isTrue();
     }
 
     @Test
     public void getByte() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select * from HallOfFame limit 10")) {
-            resultSet.next();
-            assertThat(resultSet.getByte(6)).isEqualTo((byte) 55);
-            assertThat(resultSet.getByte("votes")).isEqualTo((byte) 55);
-            assertThat(resultSet.wasNull()).isFalse();
-            assertThat(resultSet.getByte("null_col")).isEqualTo((byte) 0);
-            assertThat(resultSet.wasNull()).isTrue();
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getByte(6)).isEqualTo((byte) 55);
+        assertThat(resultSet.getByte("votes")).isEqualTo((byte) 55);
+        assertThat(resultSet.wasNull()).isFalse();
+        assertThat(resultSet.getByte("null_col")).isEqualTo((byte) 0);
+        assertThat(resultSet.wasNull()).isTrue();
     }
 
     @Test
@@ -109,133 +112,105 @@ public class GetValuesTest {
 
     @Test
     public void getDouble() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select * from HallOfFame limit 10")) {
-            resultSet.next();
-            assertThat(resultSet.getDouble(2)).isEqualTo(1936.0);
-            assertThat(resultSet.getDouble("yearid")).isEqualTo(1936.0);
-            assertThat(resultSet.wasNull()).isFalse();
-            assertThat(resultSet.getDouble("null_col")).isEqualTo(0.0);
-            assertThat(resultSet.wasNull()).isTrue();
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getDouble(2)).isEqualTo(1936.0);
+        assertThat(resultSet.getDouble("yearid")).isEqualTo(1936.0);
+        assertThat(resultSet.wasNull()).isFalse();
+        assertThat(resultSet.getDouble("null_col")).isEqualTo(0.0);
+        assertThat(resultSet.wasNull()).isTrue();
     }
 
     @Test
     public void getFloat() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select * from HallOfFame limit 10")) {
-            resultSet.next();
-            assertThat(resultSet.getFloat(2)).isEqualTo(1936.0F);
-            assertThat(resultSet.getFloat("yearid")).isEqualTo(1936.0F);
-            assertThat(resultSet.wasNull()).isFalse();
-            assertThat(resultSet.getFloat("null_col")).isEqualTo(0.0F);
-            assertThat(resultSet.wasNull()).isTrue();
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getFloat(2)).isEqualTo(1936.0F);
+        assertThat(resultSet.getFloat("yearid")).isEqualTo(1936.0F);
+        assertThat(resultSet.wasNull()).isFalse();
+        assertThat(resultSet.getFloat("null_col")).isEqualTo(0.0F);
+        assertThat(resultSet.wasNull()).isTrue();
     }
 
     @Test
     public void getInt() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select * from HallOfFame limit 10")) {
-            resultSet.next();
-            assertThat(resultSet.getInt(2)).isEqualTo(1936);
-            assertThat(resultSet.getInt("yearid")).isEqualTo(1936);
-            assertThat(resultSet.wasNull()).isFalse();
-            assertThat(resultSet.getInt("null_col")).isEqualTo(0);
-            assertThat(resultSet.wasNull()).isTrue();
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getInt(2)).isEqualTo(1936);
+        assertThat(resultSet.getInt("yearid")).isEqualTo(1936);
+        assertThat(resultSet.wasNull()).isFalse();
+        assertThat(resultSet.getInt("null_col")).isEqualTo(0);
+        assertThat(resultSet.wasNull()).isTrue();
     }
 
     @Test
     public void getLong() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select * from HallOfFame limit 10")) {
-            resultSet.next();
-            assertThat(resultSet.getLong(2)).isEqualTo(1936L);
-            assertThat(resultSet.getLong("yearid")).isEqualTo(1936L);
-            assertThat(resultSet.wasNull()).isFalse();
-            assertThat(resultSet.getLong("null_col")).isEqualTo(0L);
-            assertThat(resultSet.wasNull()).isTrue();
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getLong(2)).isEqualTo(1936L);
+        assertThat(resultSet.getLong("yearid")).isEqualTo(1936L);
+        assertThat(resultSet.wasNull()).isFalse();
+        assertThat(resultSet.getLong("null_col")).isEqualTo(0L);
+        assertThat(resultSet.wasNull()).isTrue();
     }
 
     @Test
     public void getNString() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select * from HallOfFame limit 10")) {
-            resultSet.next();
-            assertThat(resultSet.getNString(3)).isEqualTo("BBWAA");
-            assertThat(resultSet.getNString("votedBy")).isEqualTo("BBWAA");
-            assertThat(resultSet.wasNull()).isFalse();
-            assertThat(resultSet.getNString("null_col")).isEqualTo(null);
-            assertThat(resultSet.wasNull()).isTrue();
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getNString(3)).isEqualTo("BBWAA");
+        assertThat(resultSet.getNString("votedBy")).isEqualTo("BBWAA");
+        assertThat(resultSet.wasNull()).isFalse();
+        assertThat(resultSet.getNString("null_col")).isEqualTo(null);
+        assertThat(resultSet.wasNull()).isTrue();
     }
 
     @Test
     public void getObject() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select * from HallOfFame limit 10")) {
-            resultSet.next();
-            assertThat(resultSet.getObject(1)).isEqualTo("alexape01");
-            assertThat(resultSet.getObject(2)).isEqualTo(1936L);
-            assertThat(resultSet.getObject("yearid")).isEqualTo(1936L);
-            assertThat(resultSet.wasNull()).isFalse();
-            assertThat(resultSet.getObject("null_col")).isEqualTo(null);
-            assertThat(resultSet.wasNull()).isTrue();
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getObject(1)).isEqualTo("alexape01");
+        assertThat(resultSet.getObject(2)).isEqualTo(1936L);
+        assertThat(resultSet.getObject("yearid")).isEqualTo(1936L);
+        assertThat(resultSet.wasNull()).isFalse();
+        assertThat(resultSet.getObject("null_col")).isEqualTo(null);
+        assertThat(resultSet.wasNull()).isTrue();
     }
 
     @Test
     public void getObjectHiCompatability() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldStatement statement = (DataWorldStatement) connection.createStatement()) {
-                statement.setJdbcCompatibilityLevel(JdbcCompatibility.HIGH);
-                try (final ResultSet resultSet = statement.executeQuery("select * from HallOfFame limit 10")) {
-                    resultSet.next();
-                    assertThat(resultSet.getObject(1)).isEqualTo("alexape01");
-                    assertThat(resultSet.getObject(2)).isEqualTo(1936L);
-                    assertThat(resultSet.getObject("yearid")).isEqualTo(1936L);
-                    assertThat(resultSet.wasNull()).isFalse();
-                    assertThat(resultSet.getObject("null_col")).isEqualTo(null);
-                    assertThat(resultSet.wasNull()).isTrue();
-                }
-            }
-        }
+        DataWorldStatement statement = sql.createStatement(sql.connect());
+        statement.setJdbcCompatibilityLevel(JdbcCompatibility.HIGH);
+        ResultSet resultSet = sql.executeQuery(statement, "select * from HallOfFame limit 10");
+        resultSet.next();
+        assertThat(resultSet.getObject(1)).isEqualTo("alexape01");
+        assertThat(resultSet.getObject(2)).isEqualTo(1936L);
+        assertThat(resultSet.getObject("yearid")).isEqualTo(1936L);
+        assertThat(resultSet.wasNull()).isFalse();
+        assertThat(resultSet.getObject("null_col")).isEqualTo(null);
+        assertThat(resultSet.wasNull()).isTrue();
     }
 
     @Test
     public void getShort() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select * from HallOfFame limit 10")) {
-            resultSet.next();
-            assertThat(resultSet.getShort(2)).isEqualTo((short) 1936);
-            assertThat(resultSet.getShort("yearid")).isEqualTo((short) 1936);
-            assertThat(resultSet.wasNull()).isFalse();
-            assertThat(resultSet.getShort("null_col")).isEqualTo((short) 0);
-            assertThat(resultSet.wasNull()).isTrue();
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getShort(2)).isEqualTo((short) 1936);
+        assertThat(resultSet.getShort("yearid")).isEqualTo((short) 1936);
+        assertThat(resultSet.wasNull()).isFalse();
+        assertThat(resultSet.getShort("null_col")).isEqualTo((short) 0);
+        assertThat(resultSet.wasNull()).isTrue();
     }
 
     @Test
     public void getString() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select * from HallOfFame limit 10")) {
-            resultSet.next();
-            assertThat(resultSet.getString(3)).isEqualTo("BBWAA");
-            assertThat(resultSet.getString("votedBy")).isEqualTo("BBWAA");
-            assertThat(resultSet.wasNull()).isFalse();
-            assertThat(resultSet.getString("null_col")).isEqualTo(null);
-            assertThat(resultSet.wasNull()).isTrue();
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getString(3)).isEqualTo("BBWAA");
+        assertThat(resultSet.getString("votedBy")).isEqualTo("BBWAA");
+        assertThat(resultSet.wasNull()).isFalse();
+        assertThat(resultSet.getString("null_col")).isEqualTo(null);
+        assertThat(resultSet.wasNull()).isTrue();
     }
 
     @Test
@@ -257,6 +232,5 @@ public class GetValuesTest {
     public void getTimestamp1() throws Exception {
 
     }
-
 
 }

--- a/src/test/java/world/data/jdbc/results/SelectResultsTest.java
+++ b/src/test/java/world/data/jdbc/results/SelectResultsTest.java
@@ -20,165 +20,129 @@ package world.data.jdbc.results;
 
 import fi.iki.elonen.NanoHTTPD;
 import org.apache.commons.io.IOUtils;
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import world.data.jdbc.JdbcCompatibility;
-import world.data.jdbc.NanoHTTPDResource;
-import world.data.jdbc.SparqlTest;
-import world.data.jdbc.TestConfigSource;
 import world.data.jdbc.connections.DataWorldConnection;
+import world.data.jdbc.testing.NanoHTTPDHandler;
+import world.data.jdbc.testing.NanoHTTPDResource;
+import world.data.jdbc.testing.SparqlHelper;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLException;
 
 public class SelectResultsTest {
-    private static String lastUri;
-    private static final String resultResourceName = "select.json";
+    private static NanoHTTPDHandler lastBackendRequest;
+    private static final String resultResourceName = "/select.json";
     private static final String resultMimeType = "application/json";
 
     @ClassRule
     public static final NanoHTTPDResource proxiedServer = new NanoHTTPDResource(3333) {
         @Override
         protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) throws Exception {
-            final String queryParameterString = session.getQueryParameterString();
-            if (queryParameterString != null) {
-                lastUri = "http://localhost:3333" + session.getUri() + '?' + queryParameterString;
-            } else {
-                lastUri = "http://localhost:3333" + session.getUri();
-            }
-            return newResponse(NanoHTTPD.Response.Status.OK, resultMimeType, IOUtils.toString(SparqlTest.class.getResourceAsStream("/" + resultResourceName)));
+            NanoHTTPDHandler.invoke(session, lastBackendRequest);
+            String body = IOUtils.toString(getClass().getResourceAsStream(resultResourceName), UTF_8);
+            return newResponse(NanoHTTPD.Response.Status.OK, resultMimeType, body);
         }
     };
 
+    @Rule
+    public final SparqlHelper sparql = new SparqlHelper();
+
+    @Before
+    public void setup() {
+        lastBackendRequest = mock(NanoHTTPDHandler.class);
+    }
+
+    private ResultSet sampleResultSet() throws SQLException {
+        Statement statement = sparql.createStatement(sparql.connect());
+        return sparql.executeQuery(statement, "select ?s where {?s ?p ?o.}");
+    }
+
     @Test
     public void findColumn() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s where {?s ?p ?o.}")) {
-            assertThat(resultSet.findColumn("s")).isEqualTo(1);
-        }
+        ResultSet resultSet = sampleResultSet();
+        assertThat(resultSet.findColumn("s")).isEqualTo(1);
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void findColumnUnknown() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s where {?s ?p ?o.}")) {
-            assertThat(resultSet.findColumn("q"));
-        }
+        ResultSet resultSet = sampleResultSet();
+        assertSQLException(() -> resultSet.findColumn("q"));
     }
 
-    @Test(expected = SQLException.class)
-    public void findColumnClosed() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s where {?s ?p ?o.}")) {
-            resultSet.close();
-            assertThat(resultSet.findColumn("s"));
-        }
-    }
-
-    @Test(expected = SQLException.class)
+    @Test
     public void getNotAtRow() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s where {?s ?p ?o.}")) {
-            assertThat(resultSet.getURL(1)).isEqualTo(1);
-        }
+        ResultSet resultSet = sampleResultSet();
+        assertSQLException(() -> resultSet.getURL(1));
     }
 
-
-    @Test(expected = SQLException.class)
-    public void getUrClosedl() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s where {?s ?p ?o.}")) {
-            resultSet.next();
-            resultSet.close();
-            assertThat(resultSet.getURL(1)).isEqualTo(1);
-        }
-    }
-
-    @Test(expected = SQLException.class)
+    @Test
     public void getUrlOOBE() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s where {?s ?p ?o.}")) {
-            resultSet.next();
-            assertThat(resultSet.getURL(5)).isEqualTo(1);
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertSQLException(() -> resultSet.getURL(5));
     }
 
     @Test
     public void getUrl() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s where {?s ?p ?o.}")) {
-            resultSet.next();
-            assertThat(resultSet.getURL(1).toString()).isEqualTo("http://data.world/user8/lahman-baseball/");
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getURL(1).toString()).isEqualTo("http://data.world/user8/lahman-baseball/");
     }
 
     @Test
     public void getUrlByName() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s where {?s ?p ?o.}")) {
-            resultSet.next();
-            assertThat(resultSet.getURL("s").toString()).isEqualTo("http://data.world/user8/lahman-baseball/");
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertThat(resultSet.getURL("s").toString()).isEqualTo("http://data.world/user8/lahman-baseball/");
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void getUrlBadName() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s where {?s ?p ?o.}")) {
-            resultSet.next();
-            assertThat(resultSet.getURL("Q").toString()).isEqualTo("http://data.world/user8/lahman-baseball/");
-        }
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        assertSQLException(() -> resultSet.getURL("Q"));
     }
-
 
     @Test
     public void getMetaData() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties());
-             final Statement statement = connection.createStatement();
-             final ResultSet resultSet = statement.executeQuery("select ?s where {?s ?p ?o.}")) {
-            assertThat(resultSet.getMetaData().getColumnCount()).isEqualTo(3);
-        }
+        ResultSet resultSet = sampleResultSet();
+        assertThat(resultSet.getMetaData().getColumnCount()).isEqualTo(3);
     }
 
     @Test
     public void getMetaDataLow() throws Exception {
-        try (final DataWorldConnection connection =
-                     (DataWorldConnection) DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            connection.setJdbcCompatibilityLevel(JdbcCompatibility.LOW);
-            try (final Statement statement = connection.createStatement()) {
-                try (final ResultSet resultSet = statement.executeQuery("select ?s where {?s ?p ?o.}")) {
-                    assertThat(resultSet.getMetaData().getColumnCount()).isEqualTo(3);
-                }
-            }
-        }
+        DataWorldConnection connection = sparql.connect();
+        connection.setJdbcCompatibilityLevel(JdbcCompatibility.LOW);
+        Statement statement = sparql.createStatement(connection);
+        ResultSet resultSet = sparql.executeQuery(statement, "select ?s where {?s ?p ?o.}");
+        assertThat(resultSet.getMetaData().getColumnCount()).isEqualTo(3);
     }
 
     @Test
     public void getMetaDataHigh() throws Exception {
-        try (final DataWorldConnection connection =
-                     (DataWorldConnection) DriverManager.getConnection("jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            connection.setJdbcCompatibilityLevel(JdbcCompatibility.HIGH);
-            try (final Statement statement = connection.createStatement()) {
-                try (final ResultSet resultSet = statement.executeQuery("select ?s where {?s ?p ?o.}")) {
-                    assertThat(resultSet.getMetaData().getColumnCount()).isEqualTo(3);
-                }
-            }
-        }
+        DataWorldConnection connection = sparql.connect();
+        connection.setJdbcCompatibilityLevel(JdbcCompatibility.HIGH);
+        Statement statement = sparql.createStatement(connection);
+        ResultSet resultSet = sparql.executeQuery(statement, "select ?s where {?s ?p ?o.}");
+        assertThat(resultSet.getMetaData().getColumnCount()).isEqualTo(3);
     }
 
-
+    @Test
+    public void testAllClosed() throws Exception {
+        ResultSet resultSet = sampleResultSet();
+        resultSet.next();
+        resultSet.close();
+        assertSQLException(() -> resultSet.getURL(1));
+        assertSQLException(() -> resultSet.findColumn("s"));
+    }
 }

--- a/src/test/java/world/data/jdbc/statements/DataWorldPreparedStatementTest.java
+++ b/src/test/java/world/data/jdbc/statements/DataWorldPreparedStatementTest.java
@@ -19,40 +19,51 @@ package world.data.jdbc.statements;
 
 import fi.iki.elonen.NanoHTTPD;
 import org.apache.commons.io.IOUtils;
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
-import world.data.jdbc.NanoHTTPDResource;
-import world.data.jdbc.SparqlTest;
-import world.data.jdbc.TestConfigSource;
+import world.data.jdbc.testing.NanoHTTPDHandler;
+import world.data.jdbc.testing.NanoHTTPDResource;
+import world.data.jdbc.testing.SqlHelper;
 
 import java.math.BigDecimal;
-import java.sql.Connection;
 import java.sql.Date;
-import java.sql.DriverManager;
-import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLFeatureNotSupported;
 
 public class DataWorldPreparedStatementTest {
-    private static String lastUri;
-    private static final String resultResourceName = "select.json";
+    private static NanoHTTPDHandler lastBackendRequest;
+    private static final String resultResourceName = "/select.json";
     private static final String resultMimeType = "application/json";
 
     @ClassRule
     public static final NanoHTTPDResource proxiedServer = new NanoHTTPDResource(3333) {
         @Override
         protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) throws Exception {
-            final String queryParameterString = session.getQueryParameterString();
-            if (queryParameterString != null) {
-                lastUri = "http://localhost:3333" + session.getUri() + '?' + queryParameterString;
-            } else {
-                lastUri = "http://localhost:3333" + session.getUri();
-            }
-            return newResponse(NanoHTTPD.Response.Status.OK, resultMimeType, IOUtils.toString(SparqlTest.class.getResourceAsStream("/" + resultResourceName)));
+            NanoHTTPDHandler.invoke(session, lastBackendRequest);
+            String body = IOUtils.toString(getClass().getResourceAsStream(resultResourceName), UTF_8);
+            return newResponse(NanoHTTPD.Response.Status.OK, resultMimeType, body);
         }
     };
+
+    @Rule
+    public final SqlHelper sql = new SqlHelper();
+
+    @Before
+    public void setup() {
+        lastBackendRequest = mock(NanoHTTPDHandler.class);
+    }
+
+    private DataWorldPreparedStatement samplePreparedStatement() throws SQLException {
+        return sql.prepareStatement(sql.connect(), "select * from Fielding where yearid = ?");
+    }
 
     @Test
     public void addBatch() throws Exception {
@@ -91,100 +102,58 @@ public class DataWorldPreparedStatementTest {
 
     @Test
     public void setBigDecimal() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ? ")) {
-                statement.setBigDecimal(1, new BigDecimal(3));
-                assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"3\"^^<http://www.w3.org/2001/XMLSchema#decimal>");
-            }
-        }
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        statement.setBigDecimal(1, new BigDecimal(3));
+        assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"3\"^^<http://www.w3.org/2001/XMLSchema#decimal>");
     }
 
     @Test
     public void setBoolean() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ?  ")) {
-                statement.setBoolean(1, true);
-                assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>");
-            }
-        }
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        statement.setBoolean(1, true);
+        assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>");
     }
 
     @Test
     public void setDate() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ?  ")) {
-                statement.setDate(1, new Date(1477433443000L));
-                assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"2016-10-25T22:10:43+00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>");
-            }
-        }
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        statement.setDate(1, new Date(1477433443000L));
+        assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"2016-10-25T22:10:43+00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>");
     }
 
     @Test
     public void setDouble() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ? ")) {
-                statement.setDouble(1, 3.0);
-                assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"3.0\"^^<http://www.w3.org/2001/XMLSchema#double>");
-            }
-        }
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        statement.setDouble(1, 3.0);
+        assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"3.0\"^^<http://www.w3.org/2001/XMLSchema#double>");
     }
 
     @Test
     public void setFloat() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ? ")) {
-                statement.setFloat(1, 3.0F);
-                assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"3.0\"^^<http://www.w3.org/2001/XMLSchema#float>");
-            }
-        }
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        statement.setFloat(1, 3.0F);
+        assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"3.0\"^^<http://www.w3.org/2001/XMLSchema#float>");
     }
 
     @Test
     public void setInt() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ? ")) {
-                statement.setInt(1, 3);
-                assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"3\"^^<http://www.w3.org/2001/XMLSchema#integer>");
-            }
-        }
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        statement.setInt(1, 3);
+        assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"3\"^^<http://www.w3.org/2001/XMLSchema#integer>");
     }
 
     @Test
     public void setLong() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ? ")) {
-                statement.setLong(1, 3L);
-                assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"3\"^^<http://www.w3.org/2001/XMLSchema#integer>");
-            }
-        }
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        statement.setLong(1, 3L);
+        assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"3\"^^<http://www.w3.org/2001/XMLSchema#integer>");
     }
 
     @Test
     public void setNString() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ? ")) {
-                statement.setNString(1, "foo");
-                assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"foo\"");
-            }
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void setNull() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ? ")) {
-                statement.setNull(1, 1);
-            }
-        }
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void setNull1() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ? ")) {
-                statement.setNull(1, 1, "foo");
-            }
-        }
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        statement.setNString(1, "foo");
+        assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"foo\"");
     }
 
     @Test
@@ -204,51 +173,37 @@ public class DataWorldPreparedStatementTest {
 
     @Test
     public void setByte() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ? ")) {
-                statement.setByte(1, (byte) 4);
-                assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"4\"^^<http://www.w3.org/2001/XMLSchema#byte>");
-            }
-        }
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        statement.setByte(1, (byte) 4);
+        assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"4\"^^<http://www.w3.org/2001/XMLSchema#byte>");
     }
 
     @Test
     public void setShort() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ? ")) {
-                statement.setShort(1, (short) 4);
-                assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"4\"^^<http://www.w3.org/2001/XMLSchema#short>");
-            }
-        }
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        statement.setShort(1, (short) 4);
+        assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"4\"^^<http://www.w3.org/2001/XMLSchema#short>");
     }
 
     @Test
     public void setString() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ? ")) {
-                statement.setString(1, "foo");
-                assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"foo\"");
-            }
-        }
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        statement.setString(1, "foo");
+        assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"foo\"");
     }
 
     @Test
     public void setTime() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ?  ")) {
-                statement.setTime(1, new Time(1477433443000L));
-                assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"22:10:43+00:00\"^^<http://www.w3.org/2001/XMLSchema#time>");
-            }
-        }
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        statement.setTime(1, new Time(1477433443000L));
+        assertThat(statement.formatParams()).isEqualTo("$data_world_param0=\"22:10:43+00:00\"^^<http://www.w3.org/2001/XMLSchema#time>");
     }
 
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void setTimestamp() throws Exception {
-        try (final Connection connection = DriverManager.getConnection("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset", TestConfigSource.testProperties())) {
-            try (final DataWorldPreparedStatement statement = (DataWorldPreparedStatement) connection.prepareStatement("select * from Fielding where yearid = ?  ")) {
-                statement.setTimestamp(1, new Timestamp(1477433443000L));
-            }
-        }
+    @Test
+    public void testAllNotSupported() throws Exception {
+        DataWorldPreparedStatement statement = samplePreparedStatement();
+        assertSQLFeatureNotSupported(() -> statement.setNull(1, 1));
+        assertSQLFeatureNotSupported(() -> statement.setNull(1, 1, "foo"));
+        assertSQLFeatureNotSupported(() -> statement.setTimestamp(1, new Timestamp(1477433443000L)));
     }
-
 }

--- a/src/test/java/world/data/jdbc/statements/DataWorldSqlParameterMetadataTest.java
+++ b/src/test/java/world/data/jdbc/statements/DataWorldSqlParameterMetadataTest.java
@@ -19,118 +19,131 @@ package world.data.jdbc.statements;
 
 import org.junit.Test;
 
+import java.sql.ParameterMetaData;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Types;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLException;
+import static world.data.jdbc.testing.MoreAssertions.assertSQLFeatureNotSupported;
 
 public class DataWorldSqlParameterMetadataTest {
-    private final DataWorldSqlParameterMetadata metadata;
 
-    public DataWorldSqlParameterMetadataTest() throws SQLException {
-        metadata = new DataWorldSqlParameterMetadata("select * from HallOfFame where yearid > ? order by yearid, playerID ");
+    private DataWorldSqlParameterMetadata sampleMetadata() throws SQLException {
+        return new DataWorldSqlParameterMetadata("select * from HallOfFame where yearid > ? order by yearid, playerID ");
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void testNullString() throws Exception {
-        new DataWorldSqlParameterMetadata(null);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void testIsWrapperFor() throws Exception {
-        metadata.isWrapperFor(Class.class);
-    }
-
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void unwrap() throws Exception {
-        metadata.unwrap(Class.class);
+        assertSQLException(() -> new DataWorldSqlParameterMetadata(null));
     }
 
     @Test
     public void getParameterClassName() throws Exception {
+        ParameterMetaData metadata = sampleMetadata();
         assertThat(metadata.getParameterClassName(1)).isEqualTo("org.apache.jena.graph.Node");
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void getParameterClassNameOOB() throws Exception {
-        assertThat(metadata.getParameterClassName(2));
+        ParameterMetaData metadata = sampleMetadata();
+        assertSQLException(() -> metadata.getParameterClassName(2));
     }
 
     @Test
     public void getParameterCount() throws Exception {
+        ParameterMetaData metadata = sampleMetadata();
         assertThat(metadata.getParameterCount()).isEqualTo(1);
     }
 
     @Test
     public void getParameterMode() throws Exception {
+        ParameterMetaData metadata = sampleMetadata();
         assertThat(metadata.getParameterMode(1)).isEqualTo(1);
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void getParameterModeOOB() throws Exception {
-        assertThat(metadata.getParameterMode(2)).isEqualTo(1);
+        ParameterMetaData metadata = sampleMetadata();
+        assertSQLException(() -> metadata.getParameterMode(2));
     }
 
     @Test
     public void getParameterType() throws Exception {
+        ParameterMetaData metadata = sampleMetadata();
         assertThat(metadata.getParameterType(1)).isEqualTo(Types.JAVA_OBJECT);
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void getParameterTypeOOB() throws Exception {
-        assertThat(metadata.getParameterType(2));
+        ParameterMetaData metadata = sampleMetadata();
+        assertSQLException(() -> metadata.getParameterType(2));
     }
 
     @Test
     public void getParameterTypeName() throws Exception {
+        ParameterMetaData metadata = sampleMetadata();
         assertThat(metadata.getParameterTypeName(1)).isEqualTo("org.apache.jena.graph.Node");
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void getParameterTypeNameOOB() throws Exception {
-        assertThat(metadata.getParameterTypeName(2));
+        ParameterMetaData metadata = sampleMetadata();
+        assertSQLException(() -> metadata.getParameterTypeName(2));
     }
 
     @Test
     public void getPrecision() throws Exception {
+        ParameterMetaData metadata = sampleMetadata();
         assertThat(metadata.getPrecision(1)).isEqualTo(0);
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void getPrecisionOOB() throws Exception {
-        assertThat(metadata.getPrecision(3));
+        ParameterMetaData metadata = sampleMetadata();
+        assertSQLException(() -> metadata.getPrecision(3));
     }
 
     @Test
     public void getScale() throws Exception {
+        ParameterMetaData metadata = sampleMetadata();
         assertThat(metadata.getScale(1)).isEqualTo(0);
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void getScaleOOB() throws Exception {
-        assertThat(metadata.getScale(-1));
+        ParameterMetaData metadata = sampleMetadata();
+        assertSQLException(() -> metadata.getScale(-1));
     }
 
     @Test
     public void isNullable() throws Exception {
+        ParameterMetaData metadata = sampleMetadata();
         assertThat(metadata.isNullable(1)).isEqualTo(0);
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void isNullableOOB() throws Exception {
-        assertThat(metadata.isNullable(0));
+        ParameterMetaData metadata = sampleMetadata();
+        assertSQLException(() -> metadata.isNullable(0));
     }
 
     @Test
     public void isSigned() throws Exception {
+        ParameterMetaData metadata = sampleMetadata();
         assertThat(metadata.isSigned(1)).isFalse();
     }
 
-    @Test(expected = SQLException.class)
+    @Test
     public void isSignedOOB() throws Exception {
-        assertThat(metadata.isSigned(4092));
-
+        ParameterMetaData metadata = sampleMetadata();
+        assertSQLException(() -> metadata.isSigned(4092));
     }
 
+    @Test
+    public void testAllNotSupported() throws Exception {
+        ParameterMetaData metadata = sampleMetadata();
+        assertSQLFeatureNotSupported(() -> metadata.isWrapperFor(Class.class));
+        assertSQLFeatureNotSupported(() -> metadata.unwrap(Class.class));
+    }
 }

--- a/src/test/java/world/data/jdbc/testing/CloserResource.java
+++ b/src/test/java/world/data/jdbc/testing/CloserResource.java
@@ -1,0 +1,77 @@
+/*
+* dw-jdbc
+* Copyright 2016 data.world, Inc.
+
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the
+* License.
+*
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+* implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*
+* This product includes software developed at data.world, Inc.(http://www.data.world/).
+*/
+package world.data.jdbc.testing;
+
+import org.junit.rules.ExternalResource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+public class CloserResource extends ExternalResource {
+    private List<AutoCloseable> closeables;
+
+    @Override
+    protected void before() throws Throwable {
+        this.closeables = new ArrayList<>();
+    }
+
+    public <T extends AutoCloseable> T register(T closeable) {
+        requireNonNull(closeable, "closeable");
+        requireNonNull(closeables, "closeables");
+        closeables.add(closeable);
+        return closeable;
+    }
+
+    public <T> T register(T obj, Consumer<T> closer) {
+        requireNonNull(obj, "obj");
+        requireNonNull(closer, "closer");
+        register(() -> closer.accept(obj));
+        return obj;
+    }
+
+    @Override
+    protected void after() {
+        try {
+            closeAll(closeables);
+        } finally {
+            closeables = null;
+        }
+    }
+
+    private static void closeAll(List<AutoCloseable> closeables) {
+        RuntimeException first = null;
+        for (AutoCloseable closeable : closeables) {
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                if (first == null) {
+                    first = (e instanceof RuntimeException) ? (RuntimeException) e : new RuntimeException(e);
+                } else {
+                    first.addSuppressed(e);
+                }
+            }
+        }
+        if (first != null) {
+            throw first;
+        }
+    }
+}

--- a/src/test/java/world/data/jdbc/testing/MoreAssertions.java
+++ b/src/test/java/world/data/jdbc/testing/MoreAssertions.java
@@ -1,0 +1,37 @@
+/*
+* dw-jdbc
+* Copyright 2016 data.world, Inc.
+
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the
+* License.
+*
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+* implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*
+* This product includes software developed at data.world, Inc.(http://www.data.world/).
+*/
+package world.data.jdbc.testing;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class MoreAssertions {
+
+    public static void assertSQLException(ThrowingCallable callable) {
+        assertThatThrownBy(callable).isInstanceOf(SQLException.class);
+    }
+
+    public static void assertSQLFeatureNotSupported(ThrowingCallable callable) {
+        assertThatThrownBy(callable).isInstanceOf(SQLFeatureNotSupportedException.class);
+    }
+}

--- a/src/test/java/world/data/jdbc/testing/NanoHTTPDHandler.java
+++ b/src/test/java/world/data/jdbc/testing/NanoHTTPDHandler.java
@@ -1,0 +1,59 @@
+/*
+* dw-jdbc
+* Copyright 2016 data.world, Inc.
+
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the
+* License.
+*
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+* implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*
+* This product includes software developed at data.world, Inc.(http://www.data.world/).
+*/
+package world.data.jdbc.testing;
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Method;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.http.entity.ContentType;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public interface NanoHTTPDHandler {
+    void handle(Method method, String url, String queryParameters);
+
+    void handle(Method method, String url, String queryParameters, String contentType, String body);
+
+    static void invoke(IHTTPSession session, NanoHTTPDHandler handler) {
+        Method method = session.getMethod();
+        String url = session.getUri();
+        String queryParameters = session.getQueryParameterString();
+        if (method == Method.POST || method == Method.PUT) {
+            String body = null;
+            String contentType = session.getHeaders().get("content-type");
+            String requestLength = session.getHeaders().get("content-length");
+            if (requestLength != null) {
+                byte[] bytes = new byte[Integer.parseInt(requestLength)];
+                try {
+                    IOUtils.readFully(session.getInputStream(), bytes);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                body = new String(bytes, ObjectUtils.firstNonNull(ContentType.parse(contentType).getCharset(), UTF_8));
+            }
+            handler.handle(method, url, queryParameters, contentType, body);
+        } else {
+            handler.handle(method, url, queryParameters);
+        }
+    }
+}

--- a/src/test/java/world/data/jdbc/testing/NanoHTTPDResource.java
+++ b/src/test/java/world/data/jdbc/testing/NanoHTTPDResource.java
@@ -16,9 +16,11 @@
 *
 * This product includes software developed at data.world, Inc.(http://www.data.world/).
 */
-package world.data.jdbc;
+package world.data.jdbc.testing;
 
 import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
 import org.apache.http.HttpHeaders;
 import org.apache.jena.ext.com.google.common.base.Throwables;
 import org.junit.rules.ExternalResource;
@@ -53,10 +55,10 @@ public abstract class NanoHTTPDResource extends ExternalResource {
         apiServer.stop();
     }
 
-    protected abstract NanoHTTPD.Response serve(final NanoHTTPD.IHTTPSession session) throws Exception;
+    protected abstract Response serve(IHTTPSession session) throws Exception;
 
-    protected static NanoHTTPD.Response newResponse(NanoHTTPD.Response.Status status, String mimeType, String body) {
-        NanoHTTPD.Response response = NanoHTTPD.newFixedLengthResponse(status, mimeType, body);
+    protected static Response newResponse(Response.Status status, String mimeType, String body) {
+        Response response = NanoHTTPD.newFixedLengthResponse(status, mimeType, body);
         response.addHeader(HttpHeaders.CONNECTION, "close");  // avoid errors due to ignoring the POST body
         return response;
     }

--- a/src/test/java/world/data/jdbc/testing/SparqlHelper.java
+++ b/src/test/java/world/data/jdbc/testing/SparqlHelper.java
@@ -1,0 +1,54 @@
+/*
+* dw-jdbc
+* Copyright 2016 data.world, Inc.
+
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the
+* License.
+*
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+* implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*
+* This product includes software developed at data.world, Inc.(http://www.data.world/).
+*/
+package world.data.jdbc.testing;
+
+import world.data.jdbc.connections.DataWorldConnection;
+import world.data.jdbc.statements.DataWorldPreparedStatement;
+import world.data.jdbc.statements.DataWorldStatement;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class SparqlHelper extends CloserResource {
+
+    public DataWorldConnection connect() throws SQLException {
+        String url = "jdbc:data:world:sparql:dave:lahman-sabremetrics-dataset";
+        return register((DataWorldConnection) DriverManager.getConnection(url, TestConfigSource.testProperties()));
+    }
+
+    public DataWorldStatement createStatement(Connection connection) throws SQLException {
+        return register((DataWorldStatement) connection.createStatement());
+    }
+
+    public DataWorldPreparedStatement prepareStatement(Connection connection, String query) throws SQLException {
+        return register((DataWorldPreparedStatement) connection.prepareStatement(query));
+    }
+
+    public ResultSet executeQuery(Statement statement, String query) throws SQLException {
+        return register(statement.executeQuery(query));
+    }
+
+    public ResultSet executeQuery(PreparedStatement statement) throws SQLException {
+        return register(statement.executeQuery());
+    }
+}

--- a/src/test/java/world/data/jdbc/testing/SqlHelper.java
+++ b/src/test/java/world/data/jdbc/testing/SqlHelper.java
@@ -1,0 +1,54 @@
+/*
+* dw-jdbc
+* Copyright 2016 data.world, Inc.
+
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the
+* License.
+*
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+* implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*
+* This product includes software developed at data.world, Inc.(http://www.data.world/).
+*/
+package world.data.jdbc.testing;
+
+import world.data.jdbc.connections.DataWorldConnection;
+import world.data.jdbc.statements.DataWorldPreparedStatement;
+import world.data.jdbc.statements.DataWorldStatement;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class SqlHelper extends CloserResource {
+
+    public DataWorldConnection connect() throws SQLException {
+        String url = "jdbc:data:world:sql:dave:lahman-sabremetrics-dataset";
+        return register((DataWorldConnection) DriverManager.getConnection(url, TestConfigSource.testProperties()));
+    }
+
+    public DataWorldStatement createStatement(Connection connection) throws SQLException {
+        return register((DataWorldStatement) connection.createStatement());
+    }
+
+    public DataWorldPreparedStatement prepareStatement(Connection connection, String query) throws SQLException {
+        return register((DataWorldPreparedStatement) connection.prepareStatement(query));
+    }
+
+    public ResultSet executeQuery(Statement statement, String query) throws SQLException {
+        return register(statement.executeQuery(query));
+    }
+
+    public ResultSet executeQuery(PreparedStatement statement) throws SQLException {
+        return register(statement.executeQuery());
+    }
+}

--- a/src/test/java/world/data/jdbc/testing/TestConfigSource.java
+++ b/src/test/java/world/data/jdbc/testing/TestConfigSource.java
@@ -16,15 +16,15 @@
 *
 * This product includes software developed at data.world, Inc.(http://www.data.world/).
 */
-package world.data.jdbc;
+package world.data.jdbc.testing;
 
 import java.util.Properties;
 
-public class TestConfigSource {
-    public static Properties testProperties() {
-        final Properties out = new Properties();
+class TestConfigSource {
+    static Properties testProperties() {
+        Properties out = new Properties();
         out.setProperty("user", "");
-        out.setProperty("password", "token");
+        out.setProperty("password", "access-token");
         out.setProperty("querybaseurl", "http://localhost:3333");
         return out;
     }


### PR DESCRIPTION
This eliminates about 1,700 lines of test code but doesn't actually add/remove/change test behavior, with the following exceptions:

* SqlTest and SparqlTest now validate that the `Authorization` header is passed as expected.

* `NanoHTTPDResource` validation is handled via Mockito `verify(lastBackendRequest).handle(...)` instead of`assertThat(lastUri).isEqualTo(...)`.