### PR TITLE
Copy large query responses to a temp file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ If using Maven, you can use dw-jdbc by just including the following in your pom.
 </dependency>
 ```
 
+See [this link at Maven Central](https://search.maven.org/#search%7Cga%7C1%7Cdw-jdbc) to find the latest version
+number for the JDBC driver.
+
 For some database tools it's easier to install the jdbc driver if it's a single jar.  For this reason we also
 provide dw-jdbc bundled with all its dependencies under the following:
 

--- a/src/main/java/world/data/jdbc/Driver.java
+++ b/src/main/java/world/data/jdbc/Driver.java
@@ -135,7 +135,9 @@ public final class Driver implements java.sql.Driver {
             throw new SQLException("Unknown query language: " + lang);
         }
 
-        return new ConnectionImpl(queryEngine, jdbcCompatibility);
+        ConnectionImpl connection = new ConnectionImpl(queryEngine, jdbcCompatibility);
+        connection.getResources().register(queryApi);
+        return connection;
     }
 
     private static URL getQueryEndpoint(String queryBaseUrl, String lang, String agentId, String datasetId) throws SQLException {

--- a/src/main/java/world/data/jdbc/internal/transport/FileBackedInputStream.java
+++ b/src/main/java/world/data/jdbc/internal/transport/FileBackedInputStream.java
@@ -1,0 +1,199 @@
+/*
+ * dw-jdbc
+ * Copyright 2017 data.world, Inc.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * This product includes software developed at data.world, Inc.(http://www.data.world/).
+ */
+package world.data.jdbc.internal.transport;
+
+import javax.annotation.Nonnull;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.Executor;
+import java.util.concurrent.locks.AbstractQueuedLongSynchronizer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An {@link InputStream} that protects backend http servers from slow readers.
+ * <ol>
+ * <li>The first 'n' bytes are read into memory immediately to handle small responses.</li>
+ * <li>For bigger responses, a background thread starts downloading the rest of the response to a temporary file.</li>
+ * <li>Content downloaded so far can be read via the {@code FileBackedInputStream}.  Readers don't have to wait
+ * for the entire download to complete before they can make progress--a semaphore is used to ensure readers don't
+ * get ahead of the download thread.</li>
+ * </ol>
+ */
+class FileBackedInputStream extends InputStream {
+    private InputStream memIn;
+    private final Sync sync;
+    private File file;
+    private final InputStream fileIn;
+    /** Flag used by the main thread to tell the copyAsync thread that the main thread is done. */
+    private volatile boolean fileInClosed;
+    /** Flag used by the copyAsync thread to tell the main thread that copyAsync terminated abnormally. */
+    private volatile Throwable throwable;
+
+    FileBackedInputStream(InputStream in, int memLimit, Executor cachedThreadPool) throws IOException {
+        requireNonNull(in, "in");
+        requireNonNull(cachedThreadPool, "cachedThreadPool");
+
+        // Read the first 'memLimit' bytes immediately.
+        byte[] buf = new byte[memLimit];
+        int remaining = memLimit, length = 0, count;
+        while (remaining > 0 && (count = in.read(buf, length, remaining)) != -1) {
+            length += count;
+            remaining -= count;
+        }
+        this.memIn = new ByteArrayInputStream(buf, 0, length);
+
+        if (length < memLimit) {
+            // All content fits in memory
+            in.close();
+            this.sync = null;
+            this.fileIn = null;
+            this.fileInClosed = true;
+        } else {
+            // First 'memLimit' bytes are in memory. Asynchronously download the rest to a file as fast as possible.
+            // The reader can still read from FileBackedInputStream while the download is in progress.
+            this.sync = new Sync();
+            this.file = File.createTempFile("dw-jdbc", ".tmp");
+            this.fileIn = new FileInputStream(file);
+            OutputStream fileOut = new FileOutputStream(file);
+            cachedThreadPool.execute(() -> copyAsync(in, fileOut));
+        }
+    }
+
+    private void copyAsync(InputStream source, OutputStream target) {
+        try (InputStream in = source; OutputStream out = target) {
+            byte[] buf = new byte[4096];
+            int count;
+            while (!fileInClosed && (count = in.read(buf)) != -1) {
+                out.write(buf, 0, count);
+                sync.releaseShared(count);
+            }
+        } catch (Throwable t) {
+            throwable = t;
+        } finally {
+            sync.releaseShared(Long.MAX_VALUE);
+            deleteTempFile();
+        }
+    }
+
+    private void checkAsyncException() throws IOException {
+        if (throwable != null) {
+            throw new IOException(throwable.getMessage(), throwable);
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (memIn != null) {
+            int b = memIn.read();
+            if (b != -1) {
+                return b;
+            }
+            memIn = null;
+        }
+        if (fileIn != null) {
+            try {
+                sync.acquireSharedInterruptibly(1);
+                checkAsyncException();
+                return fileIn.read();
+            } catch (InterruptedException e) {
+                throw new IOException("Interrupted while reading from file.", e);
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public int read(@Nonnull byte[] b, int off, int len) throws IOException {
+        if (memIn != null) {
+            int count = memIn.read(b, off, len);
+            if (count != -1) {
+                return count;
+            }
+            memIn = null;
+        }
+        if (fileIn != null) {
+            try {
+                sync.acquireSharedInterruptibly(len);
+                checkAsyncException();
+                return fileIn.read(b, off, len);
+            } catch (InterruptedException e) {
+                throw new IOException("Interrupted while reading from file.", e);
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (!fileInClosed) {
+            fileInClosed = true;
+            fileIn.close();
+            deleteTempFile();
+        }
+    }
+
+    private synchronized void deleteTempFile() {
+        // Note that Windows won't delete an open file so we must attempt cleanup from both threads to be
+        // sure both input and output file handles are closed at the time of the delete.
+        if (fileInClosed && file != null && file.delete()) {
+            file = null;
+        }
+    }
+
+    /** A 64-bit semaphore used to make sure the file reader doesn't get ahead of the writer. */
+    @SuppressWarnings("serial")
+    private static class Sync extends AbstractQueuedLongSynchronizer {
+        @Override
+        protected long tryAcquireShared(long acquires) {
+            for (; ; ) {
+                long current = getState();
+                long next = current - acquires;
+                if (next < 0 || compareAndSetState(current, next)) {
+                    return next;
+                }
+            }
+        }
+
+        @Override
+        protected boolean tryReleaseShared(long releases) {
+            for (; ; ) {
+                long current = getState();
+                long next;
+                if (releases == Long.MAX_VALUE) {
+                    // Special case: allow sync.acquire() to obtain as much as it wants without blocking.
+                    next = Long.MAX_VALUE;
+                } else {
+                    next = current + releases;
+                    if (next < current) {
+                        throw new Error("Maximum count exceeded"); // overflow
+                    }
+                }
+                if (compareAndSetState(current, next)) {
+                    return true;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/world/data/jdbc/internal/transport/QueryApi.java
+++ b/src/main/java/world/data/jdbc/internal/transport/QueryApi.java
@@ -20,10 +20,11 @@ package world.data.jdbc.internal.transport;
 
 import world.data.jdbc.model.Node;
 
+import java.io.Closeable;
 import java.sql.SQLException;
 import java.util.Map;
 
-public interface QueryApi {
+public interface QueryApi extends Closeable {
 
     Response executeQuery(String query, Map<String, Node> parameters, Integer timeoutSeconds) throws SQLException;
 }

--- a/src/test/java/world/data/jdbc/internal/transport/FileBackedInputStreamTest.java
+++ b/src/test/java/world/data/jdbc/internal/transport/FileBackedInputStreamTest.java
@@ -1,0 +1,158 @@
+/*
+ * dw-jdbc
+ * Copyright 2017 data.world, Inc.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * This product includes software developed at data.world, Inc.(http://www.data.world/).
+ */
+package world.data.jdbc.internal.transport;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import world.data.jdbc.testing.CloserResource;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class FileBackedInputStreamTest {
+
+    @Rule
+    public final CloserResource closer = new CloserResource();
+
+    @Test
+    public void testMem() throws Exception {
+        byte[] content = genSampleBytes(256);
+        Executor executor = mock(Executor.class);
+        InputStream contentIn = spy(new ByteArrayInputStream(content));
+        try (FileBackedInputStream in = new FileBackedInputStream(contentIn, 1024, executor)) {
+            int pos = 0;
+            assertThat(in.read()).isEqualTo(content[pos++]);
+            assertThat(in.read()).isEqualTo(content[pos++]);
+            assertThat(in.read()).isEqualTo(content[pos++]);
+
+            byte[] buf1 = new byte[16];
+            assertThat(in.read(buf1)).isEqualTo(buf1.length);
+            assertThat(buf1).isEqualTo(Arrays.copyOfRange(content, pos, pos + buf1.length));
+            pos += buf1.length;
+
+            byte[] buf2 = new byte[4096];
+            assertThat(in.read(buf2)).isEqualTo(content.length - pos);
+            assertThat(buf2).startsWith(Arrays.copyOfRange(content, pos, content.length));
+
+            assertThat(in.read()).isEqualTo(-1);
+            assertThat(in.read(buf1)).isEqualTo(-1);
+        }
+        verifyZeroInteractions(executor);
+        verify(contentIn).close();
+    }
+
+    @Test
+    public void testFile() throws Exception {
+        byte[] content = genSampleBytes(256_000);
+        InputStream contentIn = spy(new ByteArrayInputStream(content));
+
+        // Setup an executor that waits a bit before starting the async copy
+        Semaphore semaphore = new Semaphore(0);
+        Executor realExecutor = newCachedExecutor();
+        Executor delayExecutor = mock(Executor.class);
+        doAnswer((InvocationOnMock iom) -> delayedExecute(realExecutor, iom.getArgument(0), semaphore))
+                .when(delayExecutor).execute(any());
+
+        try (FileBackedInputStream in = new FileBackedInputStream(contentIn, 2, delayExecutor)) {
+            int pos = 0;
+
+            // Read the first 2 bytes in memory
+            assertThat(in.read()).isEqualTo(content[pos++]);
+            assertThat(in.read()).isEqualTo(content[pos++]);
+
+            // Read the next byte from the temp file
+            semaphore.release();
+            assertThat(in.read()).isEqualTo(content[pos++]);
+            verify(delayExecutor).execute(any());
+
+            byte[] buf = new byte[4096];
+            int count;
+            while ((count = in.read(buf)) != -1) {
+                assertThat(buf).startsWith(Arrays.copyOfRange(content, pos, pos + count));
+                pos += count;
+            }
+
+            assertThat(pos).isEqualTo(content.length);
+            assertThat(in.read()).isEqualTo(-1);
+            assertThat(in.read(buf)).isEqualTo(-1);
+        }
+        verify(contentIn).close();
+    }
+
+    @Test
+    public void testEarlyClose() throws Exception {
+        byte[] content = genSampleBytes(16_000);
+        InputStream contentIn = spy(new ByteArrayInputStream(content));
+
+        // Setup an executor that waits for FileBackedInputStream.close() before starting the async copy
+        Semaphore semaphore = new Semaphore(0);
+        Executor realExecutor = newCachedExecutor();
+        Executor delayExecutor = mock(Executor.class);
+        doAnswer((InvocationOnMock iom) -> delayedExecute(realExecutor, iom.getArgument(0), semaphore))
+                .when(delayExecutor).execute(any());
+
+        new FileBackedInputStream(contentIn, 0, delayExecutor).close();
+        verifyZeroInteractions(contentIn);
+
+        // Except for closing the original InputStream, the async copy should no-op because FileBackedInputStream is closed
+        semaphore.release();
+        verify(contentIn, timeout(1000)).close();
+        verifyNoMoreInteractions(contentIn);
+    }
+
+    private byte[] genSampleBytes(int length) {
+        byte[] buf = new byte[length];
+        for (int i = 0; i < buf.length; i++) {
+            buf[i] = (byte) i;
+        }
+        return buf;
+    }
+
+    private ExecutorService newCachedExecutor() {
+        return closer.register(Executors.newCachedThreadPool(), ExecutorService::shutdown);
+    }
+
+    private Void delayedExecute(Executor executor, Runnable task, Semaphore semaphore) {
+        executor.execute(() -> {
+            try {
+                semaphore.acquire();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            task.run();
+        });
+        return null;
+    }
+}


### PR DESCRIPTION
Protect backend http servers from slow readers by downloading query responses to a temp file.  Use a background thread to do the download so readers don't have to wait for the entire download to complete before they can parse the first byte.

The main concern is to protect from clients that open a ResultSet, read a record or two, then leave the ResultSet open until garbage collection occurs.  Each such query can leave an idle connection to the http server, consuming server resources.

This brings the behavior of the jdbc driver more closely in line with most database clients that fetch the entire result set before returning it to the caller unless `setFetchSize(n)` is called to customize the behavior.