### PR TITLE
Don't throw exceptions for some unsupported features, support maxRows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <version>2.4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.10.0</version>
@@ -196,7 +202,8 @@
                                 <bannedDependencies>
                                     <excludes>
                                         <!-- The jdbc driver should use java.util.Logging, not a 3rd-party logging library -->
-                                        <exclude>commons-logging:commons-logging</exclude>
+                                        <exclude>commons-logging:commons-logging:*:*:compile</exclude>
+                                        <exclude>commons-logging:commons-logging:*:*:runtime</exclude>
                                         <exclude>log4j:log4j</exclude>
                                         <exclude>org.slf4j:slf4j-api</exclude>
 
@@ -206,7 +213,8 @@
                                         <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
                                         <exclude>com.google.guava:guava</exclude>
                                         <exclude>commons-io:commons-io:*:*:compile</exclude>
-                                        <exclude>org.apache.commons</exclude>
+                                        <exclude>org.apache.commons:*:*:compile</exclude>
+                                        <exclude>org.apache.commons:*:*:runtime</exclude>
                                         <exclude>org.apache.httpcomponents</exclude>
                                         <exclude>org.apache.jena</exclude>
                                     </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.8.6</version>
+            <version>2.9.6</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.14</version>
+            <version>1.18.0</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -68,13 +68,13 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.6.2</version>
+            <version>3.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.7.19</version>
+            <version>2.19.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -90,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -117,7 +117,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
+                <version>0.8.1</version>
                 <executions>
                     <execution>
                         <id>jacoco-initialize</id>
@@ -184,6 +184,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <id>banned-deps</id>

--- a/src/main/java/world/data/jdbc/internal/query/SparqlEngine.java
+++ b/src/main/java/world/data/jdbc/internal/query/SparqlEngine.java
@@ -104,8 +104,10 @@ public final class SparqlEngine implements QueryEngine {
     @Override
     public ResultSet execute(DataWorldStatement statement, String query, Map<String, Node> parameters, Integer timeoutSeconds)
             throws SQLException {
+        Integer maxRowsToReturn = statement.getMaxRows() != 0 ? statement.getMaxRows() : null;
+
         // Execute the query
-        Response response = queryApi.executeQuery(query, parameters, timeoutSeconds);
+        Response response = queryApi.executeQuery(query, parameters, maxRowsToReturn, timeoutSeconds);
 
         // Construct the ResultSet with the results
         try (CloseableRef cleanup = new CloseableRef(response.getCleanup())) {

--- a/src/main/java/world/data/jdbc/internal/query/SqlEngine.java
+++ b/src/main/java/world/data/jdbc/internal/query/SqlEngine.java
@@ -102,8 +102,10 @@ public class SqlEngine implements QueryEngine {
     @Override
     public ResultSet execute(DataWorldStatement statement, String query, Map<String, Node> parameters, Integer timeoutSeconds)
             throws SQLException {
+        Integer maxRowsToReturn = statement.getMaxRows() != 0 ? statement.getMaxRows() : null;
+
         // Execute the query
-        Response response = queryApi.executeQuery(query, parameters, timeoutSeconds);
+        Response response = queryApi.executeQuery(query, parameters, maxRowsToReturn, timeoutSeconds);
 
         // Construct the ResultSet with the results
         try (CloseableRef cleanup = new CloseableRef(response.getCleanup())) {

--- a/src/main/java/world/data/jdbc/internal/statements/CallableStatementImpl.java
+++ b/src/main/java/world/data/jdbc/internal/statements/CallableStatementImpl.java
@@ -47,9 +47,10 @@ import static world.data.jdbc.internal.util.Optionals.mapIfPresent;
 
 public final class CallableStatementImpl extends PreparedStatementImpl implements DataWorldCallableStatement, ReadOnlyCallableStatement {
 
-    public CallableStatementImpl(String query, QueryEngine queryEngine, DataWorldConnection connection)
+    public CallableStatementImpl(String query, QueryEngine queryEngine, DataWorldConnection connection,
+                                 int resultSetType, int resultSetConcurrency, int resultSetHoldability)
             throws SQLException {
-        super(query, queryEngine, connection);
+        super(query, queryEngine, connection, resultSetType, resultSetConcurrency, resultSetHoldability);
     }
 
     @Override

--- a/src/main/java/world/data/jdbc/internal/statements/PreparedStatementImpl.java
+++ b/src/main/java/world/data/jdbc/internal/statements/PreparedStatementImpl.java
@@ -71,9 +71,10 @@ public class PreparedStatementImpl extends StatementImpl implements DataWorldPre
      * @param connection Connection
      * @throws SQLException Thrown if there is a problem preparing the statement
      */
-    public PreparedStatementImpl(String query, QueryEngine queryEngine, DataWorldConnection connection)
+    public PreparedStatementImpl(String query, QueryEngine queryEngine, DataWorldConnection connection,
+                                 int resultSetType, int resultSetConcurrency, int resultSetHoldability)
             throws SQLException {
-        super(queryEngine, connection);
+        super(queryEngine, connection, resultSetType, resultSetConcurrency, resultSetHoldability);
         this.query = requireNonNull(query, "query");
         this.paramMetadata = queryEngine.getParameterMetaData(query);
     }

--- a/src/main/java/world/data/jdbc/internal/statements/StatementImpl.java
+++ b/src/main/java/world/data/jdbc/internal/statements/StatementImpl.java
@@ -41,6 +41,10 @@ import java.util.Queue;
 
 import static java.util.Objects.requireNonNull;
 import static world.data.jdbc.internal.util.Conditions.check;
+import static world.data.jdbc.internal.util.Conditions.checkResultSetConcurrency;
+import static world.data.jdbc.internal.util.Conditions.checkResultSetDirection;
+import static world.data.jdbc.internal.util.Conditions.checkResultSetHoldability;
+import static world.data.jdbc.internal.util.Conditions.checkResultSetType;
 import static world.data.jdbc.internal.util.Conditions.checkSupported;
 import static world.data.jdbc.internal.util.Optionals.or;
 
@@ -50,8 +54,9 @@ public class StatementImpl implements DataWorldStatement, ReadOnlyStatement, Res
     private static final int NO_LIMIT = 0;
 
     private int timeout = NO_LIMIT;
+    private int maxRows = NO_LIMIT;
     private JdbcCompatibility compatibilityLevel;
-    private SQLWarning warnings = null;
+    private SQLWarning warnings;
 
     final QueryEngine queryEngine;
     private final DataWorldConnection connection;
@@ -63,9 +68,18 @@ public class StatementImpl implements DataWorldStatement, ReadOnlyStatement, Res
     private ResultSet currResults;
     private boolean closed;
 
-    public StatementImpl(QueryEngine queryEngine, DataWorldConnection connection) {
+    public StatementImpl(QueryEngine queryEngine, DataWorldConnection connection,
+                         int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+            throws SQLException {
         this.queryEngine = requireNonNull(queryEngine, "queryEngine");
         this.connection = requireNonNull(connection, "connection");
+
+        checkResultSetType(resultSetType);
+        checkResultSetConcurrency(resultSetConcurrency);
+        checkResultSetHoldability(resultSetHoldability);
+        checkSupported(resultSetType == ResultSet.TYPE_FORWARD_ONLY, "Only forward-only result sets are supported");
+        checkSupported(resultSetConcurrency == ResultSet.CONCUR_READ_ONLY, "Only read-only concurrency result sets are supported");
+
         ((ResourceContainer) connection).getResources().register(this);
     }
 
@@ -115,62 +129,70 @@ public class StatementImpl implements DataWorldStatement, ReadOnlyStatement, Res
     }
 
     @Override
-    public final DataWorldConnection getConnection() {
+    public final DataWorldConnection getConnection() throws SQLException {
+        checkClosed();
         return connection;
     }
 
     @Override
-    public final void clearWarnings() {
+    public final void clearWarnings() throws SQLException {
+        checkClosed();
         warnings = null;
     }
 
     @Override
-    public final int getFetchDirection() {
+    public final int getFetchDirection() throws SQLException {
+        checkClosed();
         return ResultSet.FETCH_FORWARD;
     }
 
     @Override
-    public final int getFetchSize() {
+    public final int getFetchSize() throws SQLException {
+        checkClosed();
         return 0;
     }
 
     @Override
-    public final int getMaxFieldSize() {
+    public final int getMaxFieldSize() throws SQLException {
+        checkClosed();
         return NO_LIMIT;
     }
 
     @Override
-    public final int getMaxRows() {
-        return NO_LIMIT;
+    public final int getMaxRows() throws SQLException {
+        checkClosed();
+        return maxRows;
     }
 
     /**
      * Gets that result sets are read-only
      */
     @Override
-    public final int getResultSetConcurrency() {
+    public final int getResultSetConcurrency() throws SQLException {
+        checkClosed();
         return ResultSet.CONCUR_READ_ONLY;
     }
 
     @Override
-    public final int getResultSetHoldability() {
+    public final int getResultSetHoldability() throws SQLException {
+        checkClosed();
         return ResultSet.CLOSE_CURSORS_AT_COMMIT;
     }
 
     @Override
-    public final int getResultSetType() {
+    public final int getResultSetType() throws SQLException {
+        checkClosed();
         return ResultSet.TYPE_FORWARD_ONLY;
     }
 
     @Override
-    public final SQLWarning getWarnings() {
+    public final SQLWarning getWarnings() throws SQLException {
+        checkClosed();
         return warnings;
     }
 
     /**
      * Helper method that derived classes may use to set warnings
-     *
-     * @param warning Warning
      */
     private void setWarning(SQLWarning warning) {
         log.warning("SQL Warning was issued: " + warning);
@@ -200,7 +222,7 @@ public class StatementImpl implements DataWorldStatement, ReadOnlyStatement, Res
         doAddBatch(query, Collections.emptyMap());
     }
 
-    void doAddBatch(String query, Map<String, Node> params) throws SQLException {
+    void doAddBatch(String query, Map<String, Node> params) {
         commands.add(new BatchItem(query, params));
     }
 
@@ -290,28 +312,32 @@ public class StatementImpl implements DataWorldStatement, ReadOnlyStatement, Res
 
     @Override
     public final void setFetchDirection(int direction) throws SQLException {
-        checkSupported(direction == ResultSet.FETCH_FORWARD, "Only ResultSet.FETCH_FORWARD is supported as a fetch direction");
+        checkResultSetDirection(direction);
+        // The fetch direction is a hint that this driver ignores
     }
 
     @Override
-    public final void setFetchSize(int rows) {
-        setWarning("setMaxFieldSize() was called but there is no fetch size control for data.world JDBC connections");
+    public final void setFetchSize(int rows) throws SQLException {
+        check(rows >= 0, "rows must be non-negative");
     }
 
     @Override
-    public final void setMaxFieldSize(int max) {
-        // Ignored
+    public final void setMaxFieldSize(int max) throws SQLException {
+        check(max >= 0, "max must be non-negative");
         setWarning("setMaxFieldSize() was called but there is no field size limit for data.world JDBC connections");
     }
 
     @Override
-    public final void setMaxRows(int max) {
-        setWarning("setMaxRows() was called but there is no row size limit for data.world JDBC connections");
+    public final void setMaxRows(int max) throws SQLException {
+        check(max >= 0, "max must be non-negative");
+        this.maxRows = max;
     }
 
     @Override
     public final void setPoolable(boolean poolable) {
-        setWarning("setPoolable() was called but data.world JDBC statements are always considered poolable");
+        if (!poolable) {
+            setWarning("setPoolable() was called but data.world JDBC statements are always considered poolable");
+        }
     }
 
     @Override
@@ -330,8 +356,7 @@ public class StatementImpl implements DataWorldStatement, ReadOnlyStatement, Res
     @Override
     @SuppressWarnings("javadoc")
     public final void closeOnCompletion() throws SQLException {
-        // We don't support the JDBC 4.1 feature of closing statements
-        // automatically
+        // We don't support the JDBC 4.1 feature of closing statements automatically
         throw new SQLFeatureNotSupportedException();
     }
 

--- a/src/main/java/world/data/jdbc/internal/transport/HttpQueryApi.java
+++ b/src/main/java/world/data/jdbc/internal/transport/HttpQueryApi.java
@@ -74,7 +74,8 @@ public final class HttpQueryApi implements QueryApi {
     }
 
     @Override
-    public Response executeQuery(String query, Map<String, Node> parameters, Integer timeoutSeconds) throws SQLException {
+    public Response executeQuery(String query, Map<String, Node> parameters,
+                                 Integer maxRowsToReturn, Integer timeoutSeconds) throws SQLException {
         requireNonNull(query, "query");
         requireNonNull(parameters, "parameters");
 
@@ -88,6 +89,9 @@ public final class HttpQueryApi implements QueryApi {
             if (value != null) {
                 requestParams.put(name, value.toString());
             }
+        }
+        if (maxRowsToReturn != null) {
+            requestParams.put("maxRowsReturned", Integer.toString(maxRowsToReturn));
         }
 
         // Execute the request

--- a/src/main/java/world/data/jdbc/internal/transport/QueryApi.java
+++ b/src/main/java/world/data/jdbc/internal/transport/QueryApi.java
@@ -26,5 +26,6 @@ import java.util.Map;
 
 public interface QueryApi extends Closeable {
 
-    Response executeQuery(String query, Map<String, Node> parameters, Integer timeoutSeconds) throws SQLException;
+    Response executeQuery(String query, Map<String, Node> parameters,
+                          Integer maxRowsToReturn, Integer timeoutSeconds) throws SQLException;
 }

--- a/src/main/java/world/data/jdbc/internal/util/Conditions.java
+++ b/src/main/java/world/data/jdbc/internal/util/Conditions.java
@@ -20,8 +20,11 @@ package world.data.jdbc.internal.util;
 
 import lombok.experimental.UtilityClass;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
 
 @UtilityClass
 public final class Conditions {
@@ -47,6 +50,53 @@ public final class Conditions {
     public static void checkSupported(boolean flag, String message) throws SQLException {
         if (!flag) {
             throw new SQLFeatureNotSupportedException(message);
+        }
+    }
+
+    public static void checkConnectionTransactionIsolation(int level) throws SQLException {
+        if (level != Connection.TRANSACTION_NONE &&
+                level != Connection.TRANSACTION_READ_UNCOMMITTED &&
+                level != Connection.TRANSACTION_READ_COMMITTED &&
+                level != Connection.TRANSACTION_REPEATABLE_READ &&
+                level != Connection.TRANSACTION_SERIALIZABLE) {
+            throw new SQLException(String.format("%d is not a valid transaction isolation level", level));
+        }
+    }
+
+    public static void checkStatementGeneratedKeys(int generatedKeys) throws SQLException {
+        if (generatedKeys != Statement.NO_GENERATED_KEYS &&
+                generatedKeys != Statement.RETURN_GENERATED_KEYS) {
+            throw new SQLException(String.format("%d is not a valid generated keys value", generatedKeys));
+        }
+    }
+
+    public static void checkResultSetConcurrency(int concurrency) throws SQLException {
+        if (concurrency != ResultSet.CONCUR_READ_ONLY &&
+                concurrency != ResultSet.CONCUR_UPDATABLE) {
+            throw new SQLException(String.format("%d is not a valid result set concurrency", concurrency));
+        }
+    }
+
+    public static void checkResultSetDirection(int direction) throws SQLException {
+        if (direction != ResultSet.FETCH_FORWARD &&
+                direction != ResultSet.FETCH_REVERSE &&
+                direction != ResultSet.FETCH_UNKNOWN) {
+            throw new SQLException(String.format("%d is not a valid result set fetch direction", direction));
+        }
+    }
+
+    public static void checkResultSetHoldability(int holdability) throws SQLException {
+        if (holdability != ResultSet.HOLD_CURSORS_OVER_COMMIT &&
+                holdability != ResultSet.CLOSE_CURSORS_AT_COMMIT) {
+            throw new SQLException(String.format("%d is not a valid result set holdability", holdability));
+        }
+    }
+
+    public static void checkResultSetType(int type) throws SQLException {
+        if (type != ResultSet.TYPE_FORWARD_ONLY &&
+                type != ResultSet.TYPE_SCROLL_INSENSITIVE &&
+                type != ResultSet.TYPE_SCROLL_SENSITIVE) {
+            throw new SQLException(String.format("%d is not a valid result set type", type));
         }
     }
 }

--- a/src/main/java/world/data/jdbc/internal/util/LimitedIterator.java
+++ b/src/main/java/world/data/jdbc/internal/util/LimitedIterator.java
@@ -1,6 +1,6 @@
 /*
  * dw-jdbc
- * Copyright 2017 data.world, Inc.
+ * Copyright 2018 data.world, Inc.
 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/src/main/java/world/data/jdbc/internal/util/LimitedIterator.java
+++ b/src/main/java/world/data/jdbc/internal/util/LimitedIterator.java
@@ -1,0 +1,58 @@
+/*
+ * dw-jdbc
+ * Copyright 2017 data.world, Inc.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * This product includes software developed at data.world, Inc.(http://www.data.world/).
+ */
+package world.data.jdbc.internal.util;
+
+import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static world.data.jdbc.internal.util.Conditions.check;
+
+/**
+ * An {@code Iterator} that returns at most {@code max} items.
+ */
+public final class LimitedIterator<T> implements Iterator<T> {
+    private final Iterator<T> delegate;
+    private int remaining;
+
+    public LimitedIterator(Iterator<T> delegate, int max) throws SQLException {
+        check(max >= 0, "max must be non-negative");
+        this.delegate = delegate;
+        this.remaining = max;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return remaining > 0 && delegate.hasNext();
+    }
+
+    @Override
+    public T next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        remaining--;
+        return delegate.next();
+    }
+
+    @Override
+    public void remove() {
+        delegate.remove();
+    }
+}

--- a/src/main/java/world/data/jdbc/internal/util/WarningList.java
+++ b/src/main/java/world/data/jdbc/internal/util/WarningList.java
@@ -1,3 +1,21 @@
+/*
+ * dw-jdbc
+ * Copyright 2018 data.world, Inc.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * This product includes software developed at data.world, Inc.(http://www.data.world/).
+ */
 package world.data.jdbc.internal.util;
 
 import lombok.extern.java.Log;

--- a/src/main/java/world/data/jdbc/internal/util/WarningList.java
+++ b/src/main/java/world/data/jdbc/internal/util/WarningList.java
@@ -1,0 +1,32 @@
+package world.data.jdbc.internal.util;
+
+import lombok.extern.java.Log;
+
+import java.sql.SQLWarning;
+
+@Log
+public class WarningList {
+    private SQLWarning head, tail;
+
+    public synchronized SQLWarning get() {
+        return head;
+    }
+
+    public void add(String warning) {
+        add(new SQLWarning(warning));
+    }
+
+    public synchronized void add(SQLWarning warning) {
+        log.warning("SQL Warning was issued: " + warning);
+        if (head == null) {
+            head = warning;
+        } else {
+            tail.setNextWarning(warning); // chain with existing warnings
+        }
+        tail = warning;
+    }
+
+    public synchronized void clear() {
+        head = tail = null;
+    }
+}

--- a/src/test/java/world/data/jdbc/internal/statements/StatementTest.java
+++ b/src/test/java/world/data/jdbc/internal/statements/StatementTest.java
@@ -104,7 +104,7 @@ public class StatementTest {
     @Test
     public void getWarnings() throws Exception {
         DataWorldStatement statement = sparql.createStatement(sparql.connect());
-        statement.setFetchSize(100);
+        statement.setMaxFieldSize(100);
         assertThat((Throwable) statement.getWarnings()).isNotNull();
         assertThat((Iterable<Throwable>) statement.getWarnings()).isNotEmpty();
     }
@@ -112,7 +112,7 @@ public class StatementTest {
     @Test
     public void getClearWarnings() throws Exception {
         DataWorldStatement statement = sparql.createStatement(sparql.connect());
-        statement.setFetchSize(100);
+        statement.setMaxFieldSize(100);
         assertThat((Throwable) statement.getWarnings()).isNotNull();
         assertThat((Iterable<Throwable>) statement.getWarnings()).isNotEmpty();
         statement.clearWarnings();
@@ -143,7 +143,6 @@ public class StatementTest {
         assertThat(statement.getMoreResults()).isTrue();
         assertThat(statement.getMoreResults()).isFalse();
         assertThat(statement.getResultSet()).isNull();
-
     }
 
     @Test
@@ -203,6 +202,10 @@ public class StatementTest {
     public void setFetchDirection() throws Exception {
         DataWorldStatement statement = sparql.createStatement(sparql.connect());
         statement.setFetchDirection(ResultSet.FETCH_FORWARD);
+        assertThat(statement.getFetchDirection()).isEqualTo(ResultSet.FETCH_FORWARD);
+
+        statement.setFetchDirection(ResultSet.FETCH_REVERSE);
+        assertThat(statement.getFetchDirection()).isEqualTo(ResultSet.FETCH_FORWARD);
     }
 
     @Test
@@ -222,7 +225,7 @@ public class StatementTest {
     @Test
     public void setPoolable() throws Exception {
         DataWorldStatement statement = sparql.createStatement(sparql.connect());
-        statement.setPoolable(true);
+        statement.setPoolable(false);
         assertThat((Throwable) statement.getWarnings()).isNotNull();
         assertThat((Iterable<Throwable>) statement.getWarnings()).isNotEmpty();
     }
@@ -252,7 +255,7 @@ public class StatementTest {
     public void multipleWarnings() throws Exception {
         DataWorldStatement statement = sparql.createStatement(sparql.connect());
         statement.setMaxFieldSize(100);
-        statement.setMaxRows(100);
+        statement.setPoolable(false);
         assertThat((Throwable) statement.getWarnings()).isNotNull();
         assertThat((Throwable) statement.getWarnings().getNextWarning()).isNotNull();
         assertThat((Iterable<Throwable>) statement.getWarnings()).hasSize(2);
@@ -339,6 +342,5 @@ public class StatementTest {
         assertSQLFeatureNotSupported(() -> statement.executeUpdate("foo", new int[0]));
         assertSQLFeatureNotSupported(statement::getGeneratedKeys);
         assertSQLFeatureNotSupported(() -> statement.setCursorName("foo"));
-        assertSQLFeatureNotSupported(() -> statement.setFetchDirection(ResultSet.FETCH_REVERSE));
     }
 }

--- a/src/test/java/world/data/jdbc/internal/util/LimitedIteratorTest.java
+++ b/src/test/java/world/data/jdbc/internal/util/LimitedIteratorTest.java
@@ -1,0 +1,64 @@
+/*
+ * dw-jdbc
+ * Copyright 2017 data.world, Inc.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * This product includes software developed at data.world, Inc.(http://www.data.world/).
+ */
+package world.data.jdbc.internal.util;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class LimitedIteratorTest {
+
+    @Test
+    public void testEmpty() throws Exception {
+        Iterator<String> sourceIter = Arrays.asList("a", "b").iterator();
+        LimitedIterator<String> limitedIter = new LimitedIterator<>(sourceIter, 0);
+        assertThat(limitedIter.hasNext()).isFalse();
+        assertThatThrownBy(limitedIter::next).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        Iterator<String> sourceIter = Arrays.asList("a", "b").iterator();
+        LimitedIterator<String> limitedIter = new LimitedIterator<>(sourceIter, 1);
+
+        assertThat(limitedIter.hasNext()).isTrue();
+        assertThat(limitedIter.next()).isEqualTo("a");
+
+        assertThat(limitedIter.hasNext()).isFalse();
+        assertThatThrownBy(limitedIter::next).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void testMore() throws Exception {
+        Iterator<String> sourceIter = Collections.singletonList("a").iterator();
+        LimitedIterator<String> limitedIter = new LimitedIterator<>(sourceIter, 2);
+
+        assertThat(limitedIter.hasNext()).isTrue();
+        assertThat(limitedIter.next()).isEqualTo("a");
+
+        assertThat(limitedIter.hasNext()).isFalse();
+        assertThatThrownBy(limitedIter::next).isInstanceOf(NoSuchElementException.class);
+    }
+}

--- a/src/test/java/world/data/jdbc/internal/util/LimitedIteratorTest.java
+++ b/src/test/java/world/data/jdbc/internal/util/LimitedIteratorTest.java
@@ -1,6 +1,6 @@
 /*
  * dw-jdbc
- * Copyright 2017 data.world, Inc.
+ * Copyright 2018 data.world, Inc.
 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/src/test/java/world/data/jdbc/testing/SqlHelper.java
+++ b/src/test/java/world/data/jdbc/testing/SqlHelper.java
@@ -18,11 +18,14 @@
  */
 package world.data.jdbc.testing;
 
+import org.apache.commons.dbcp2.BasicDataSource;
 import world.data.jdbc.DataWorldCallableStatement;
 import world.data.jdbc.DataWorldConnection;
 import world.data.jdbc.DataWorldPreparedStatement;
 import world.data.jdbc.DataWorldStatement;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -56,5 +59,15 @@ public class SqlHelper extends CloserResource {
 
     public ResultSet executeQuery(DataWorldPreparedStatement statement) throws SQLException {
         return register(statement.executeQuery());
+    }
+
+    public DataSource createPool() {
+        BasicDataSource ds = new BasicDataSource();
+        ds.setDriverClassName("world.data.jdbc.Driver");
+        ds.setUrl("jdbc:data:world:sql:dave:lahman-sabremetrics-dataset");
+        TestConfigSource.testProperties().forEach((k, v) -> ds.addConnectionProperty((String) k, (String) v));
+        ds.setDefaultReadOnly(false);
+        ds.setDefaultTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+        return register(ds);
     }
 }


### PR DESCRIPTION
Relax validation of cursor holdability.  Since the driver doesn't support cursors it ignores calls to change holdability.

Relax validation of connection readOnly.  Calling `cxn.setReadOnly(false)` adds a `SQLWarning` and no longer throws an exception.

Relax validation of transaction isolation.  Calling `cxn.setTransactionIsolation(..)` with anything other than `TRANSACTION_NONE` adds a `SQLWarning` and no longer throws an exception.

Relax validation of statement poolable.  Calling `stmt.setPoolable(false)` adds a `SQLWarning` and no longer throws an exception.

Relax validation of result set fetch direction.  It is a hint that the driver is free to ignore and does ignore.

Stricter checking for certain `int` enum-style parameters as specified in the JDBC Javadoc.

Implement `Statement.setMaxRows()`.  The limit is enforced by the server when possible, for efficiency.  Just in case, it's also enforced by the client.

Add a sniff test using Apache Commons DBCP connection pool (`commons-dbcp2`).